### PR TITLE
카카오 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
     // Spring Configuration Processor
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
+    // Spring Open Feign (Feign Client)
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.0'
+
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/ajou/hertz/common/auth/controller/AuthControllerV1.java
+++ b/src/main/java/com/ajou/hertz/common/auth/controller/AuthControllerV1.java
@@ -8,9 +8,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ajou.hertz.common.auth.dto.JwtTokenInfoDto;
+import com.ajou.hertz.common.auth.dto.request.KakaoLoginRequest;
 import com.ajou.hertz.common.auth.dto.request.LoginRequest;
 import com.ajou.hertz.common.auth.dto.response.JwtTokenInfoResponse;
 import com.ajou.hertz.common.auth.service.AuthService;
+import com.ajou.hertz.common.kakao.service.KakaoService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -27,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class AuthControllerV1 {
 
 	private final AuthService authService;
+	private final KakaoService kakaoService;
 
 	@Operation(
 		summary = "로그인",
@@ -40,6 +43,27 @@ public class AuthControllerV1 {
 	@PostMapping(value = "/login", headers = API_MINOR_VERSION_HEADER_NAME + "=" + 1)
 	public JwtTokenInfoResponse loginV1_1(@RequestBody @Valid LoginRequest loginRequest) {
 		JwtTokenInfoDto jwtTokenInfoDto = authService.login(loginRequest);
+		return JwtTokenInfoResponse.from(jwtTokenInfoDto);
+	}
+
+	@Operation(
+		summary = "카카오 로그인",
+		description = "카카오 로그인을 진행합니다."
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "200"),
+		@ApiResponse(
+			responseCode = "409", content = @Content,
+			description = """
+				<p>[2200] 이미 다른 사용자가 사용 중인 이메일로 신규 회원을 등록하려고 하는 경우
+				<p>[2203] 이미 다른 사용자가 사용 중인 전화번호로 신규 회원을 등록하려고 하는 경우
+				"""
+		),
+		@ApiResponse(responseCode = "Any", description = "[10000] 카카오 서버와의 통신 중 오류가 발생한 경우. Http status code는 kakao에서 응답받은 것과 동일하게 설정하여 응답한다.", content = @Content)
+	})
+	@PostMapping(value = "/login/kakao", headers = API_MINOR_VERSION_HEADER_NAME + "=" + 1)
+	public JwtTokenInfoResponse kakaoLoginV1_1(@RequestBody @Valid KakaoLoginRequest kakaoLoginRequest) {
+		JwtTokenInfoDto jwtTokenInfoDto = kakaoService.login(kakaoLoginRequest);
 		return JwtTokenInfoResponse.from(jwtTokenInfoDto);
 	}
 }

--- a/src/main/java/com/ajou/hertz/common/auth/controller/AuthControllerV1.java
+++ b/src/main/java/com/ajou/hertz/common/auth/controller/AuthControllerV1.java
@@ -13,6 +13,7 @@ import com.ajou.hertz.common.auth.dto.response.JwtTokenInfoResponse;
 import com.ajou.hertz.common.auth.service.AuthService;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -33,8 +34,8 @@ public class AuthControllerV1 {
 	)
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "OK"),
-		@ApiResponse(responseCode = "400", description = "[2003] 비밀번호가 일치하지 않는 경우"),
-		@ApiResponse(responseCode = "404", description = "[2202] 이메일에 해당하는 유저를 찾을 수 없는 경우")
+		@ApiResponse(responseCode = "400", description = "[2003] 비밀번호가 일치하지 않는 경우", content = @Content),
+		@ApiResponse(responseCode = "404", description = "[2202] 이메일에 해당하는 유저를 찾을 수 없는 경우", content = @Content)
 	})
 	@PostMapping(value = "/login", headers = API_MINOR_VERSION_HEADER_NAME + "=" + 1)
 	public JwtTokenInfoResponse loginV1_1(@RequestBody @Valid LoginRequest loginRequest) {

--- a/src/main/java/com/ajou/hertz/common/auth/controller/AuthControllerV1.java
+++ b/src/main/java/com/ajou/hertz/common/auth/controller/AuthControllerV1.java
@@ -61,7 +61,7 @@ public class AuthControllerV1 {
 		),
 		@ApiResponse(responseCode = "Any", description = "[10000] 카카오 서버와의 통신 중 오류가 발생한 경우. Http status code는 kakao에서 응답받은 것과 동일하게 설정하여 응답한다.", content = @Content)
 	})
-	@PostMapping(value = "/login/kakao", headers = API_MINOR_VERSION_HEADER_NAME + "=" + 1)
+	@PostMapping(value = "/kakao/login", headers = API_MINOR_VERSION_HEADER_NAME + "=" + 1)
 	public JwtTokenInfoResponse kakaoLoginV1_1(@RequestBody @Valid KakaoLoginRequest kakaoLoginRequest) {
 		JwtTokenInfoDto jwtTokenInfoDto = kakaoService.login(kakaoLoginRequest);
 		return JwtTokenInfoResponse.from(jwtTokenInfoDto);

--- a/src/main/java/com/ajou/hertz/common/auth/dto/request/KakaoLoginRequest.java
+++ b/src/main/java/com/ajou/hertz/common/auth/dto/request/KakaoLoginRequest.java
@@ -1,0 +1,22 @@
+package com.ajou.hertz.common.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class KakaoLoginRequest {
+
+	@Schema(description = "카카오 '인가 코드 받기'를 통해 얻은 인가 코드", example = "v9rZPkB2nyKTFX26E8ByNzUojqi6w9bQRyfBQCFDzRFhxcoUUSVpI_3HgPIKlwzSAAABjbztS6bkNSpXBP-m7E")
+	@NotBlank
+	private String authorizationCode;
+
+	@Schema(description = "인가 코드가 리다이렉트된 uri", example = "https://hertz.com/kakao-login-redirection")
+	@NotBlank
+	private String redirectUri;
+}

--- a/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
@@ -42,7 +42,8 @@ public class SecurityConfig {
 	private static final Map<String, HttpMethod> AUTH_WHITE_LIST = Map.of(
 		"/v*/users", POST,
 		"/v*/users/existence", GET,
-		"/v*/auth/login", POST
+		"/v*/auth/login", POST,
+		"/v*/auth/login/kakao", POST
 	);
 
 	@Bean

--- a/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
 		"/v*/users", POST,
 		"/v*/users/existence", GET,
 		"/v*/auth/login", POST,
-		"/v*/auth/login/kakao", POST
+		"/v*/auth/kakao/login", POST
 	);
 
 	@Bean

--- a/src/main/java/com/ajou/hertz/common/config/feign/FeignConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/feign/FeignConfig.java
@@ -1,0 +1,9 @@
+package com.ajou.hertz.common.config.feign;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@EnableFeignClients(basePackages = "com.ajou.hertz")
+@Configuration
+public class FeignConfig {
+}

--- a/src/main/java/com/ajou/hertz/common/config/feign/KakaoFeignConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/feign/KakaoFeignConfig.java
@@ -1,0 +1,24 @@
+package com.ajou.hertz.common.config.feign;
+
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.boot.autoconfigure.http.HttpMessageConverters;
+import org.springframework.cloud.openfeign.support.SpringEncoder;
+import org.springframework.context.annotation.Bean;
+
+import feign.Logger;
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
+import feign.form.spring.SpringFormEncoder;
+
+public class KakaoFeignConfig {
+
+	@Bean
+	public Encoder encoder(ObjectFactory<HttpMessageConverters> converters) {
+		return new SpringFormEncoder(new SpringEncoder(converters));
+	}
+
+	@Bean
+	public ErrorDecoder errorDecoder() {
+		return new KakaoFeignErrorDecoder();
+	}
+}

--- a/src/main/java/com/ajou/hertz/common/config/feign/KakaoFeignErrorDecoder.java
+++ b/src/main/java/com/ajou/hertz/common/config/feign/KakaoFeignErrorDecoder.java
@@ -1,0 +1,35 @@
+package com.ajou.hertz.common.config.feign;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.http.HttpStatus;
+
+import com.ajou.hertz.common.exception.IOProcessingException;
+import com.ajou.hertz.common.kakao.dto.response.KakaoErrorResponse;
+import com.ajou.hertz.common.kakao.exception.KakaoClientException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+
+public class KakaoFeignErrorDecoder implements ErrorDecoder {
+
+	private final ObjectMapper mapper;
+
+	public KakaoFeignErrorDecoder() {
+		this.mapper = new ObjectMapper();
+	}
+
+	@Override
+	public Exception decode(String methodKey, Response response) {
+		try (InputStream responseBody = response.body().asInputStream()) {
+			return new KakaoClientException(
+				HttpStatus.valueOf(response.status()),
+				mapper.readValue(responseBody, KakaoErrorResponse.class)
+			);
+		} catch (IOException e) {
+			return new IOProcessingException(e);
+		}
+	}
+}

--- a/src/main/java/com/ajou/hertz/common/exception/IOProcessingException.java
+++ b/src/main/java/com/ajou/hertz/common/exception/IOProcessingException.java
@@ -1,0 +1,18 @@
+package com.ajou.hertz.common.exception;
+
+import java.io.IOException;
+
+import com.ajou.hertz.common.exception.constant.CustomExceptionType;
+
+/**
+ * <p>I/O 작업에서 문제가 발생했을 때 사용하는 일반적인 exception class.
+ * <p>Checked exception을 {@link IOException}을 감싸 처리하는 용도로도 사용한다.
+ *
+ * @see IOException
+ */
+public class IOProcessingException extends InternalServerException {
+
+	public IOProcessingException(Throwable cause) {
+		super(CustomExceptionType.IO_PROCESSING, cause);
+	}
+}

--- a/src/main/java/com/ajou/hertz/common/exception/constant/CustomExceptionType.java
+++ b/src/main/java/com/ajou/hertz/common/exception/constant/CustomExceptionType.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 public enum CustomExceptionType {
 
 	MULTIPART_FILE_NOT_READABLE(1000, "파일을 읽을 수 없습니다. 올바른 파일인지 다시 확인 후 요청해주세요."),
+	IO_PROCESSING(1001, "입출력 처리 중 오류가 발생했습니다."),
 
 	/**
 	 * 로그인, 인증 관련 예외
@@ -36,6 +37,8 @@ public enum CustomExceptionType {
 	USER_PHONE_DUPLICATION(2203, "이미 사용 중인 전화번호입니다."),
 	USER_KAKAO_UID_DUPLICATION(2204, "이미 가입한 계정입니다."),
 	USER_NOT_FOUND_BY_KAKAO_UID(2205, "일치하는 회원을 찾을 수 없습니다."),
+
+	KAKAO_CLIENT(10000, "카카오 서버와의 통신 중 오류가 발생했습니다."),
 	;
 
 	private final Integer code;

--- a/src/main/java/com/ajou/hertz/common/exception/constant/CustomExceptionType.java
+++ b/src/main/java/com/ajou/hertz/common/exception/constant/CustomExceptionType.java
@@ -30,9 +30,13 @@ public enum CustomExceptionType {
 	/**
 	 * 유저 관련 예외
 	 */
-	USER_EMAIL_DUPLICATION(2200, "이미 다른 회원이 사용 중인 이메일입니다."),
+	USER_EMAIL_DUPLICATION(2200, "이미 사용 중인 이메일입니다."),
 	USER_NOT_FOUND_BY_ID(2201, "일치하는 회원을 찾을 수 없습니다."),
-	USER_NOT_FOUND_BY_EMAIL(2202, "일치하는 회원을 찾을 수 없습니다.");
+	USER_NOT_FOUND_BY_EMAIL(2202, "일치하는 회원을 찾을 수 없습니다."),
+	USER_PHONE_DUPLICATION(2203, "이미 사용 중인 전화번호입니다."),
+	USER_KAKAO_UID_DUPLICATION(2204, "이미 가입한 계정입니다."),
+	USER_NOT_FOUND_BY_KAKAO_UID(2205, "일치하는 회원을 찾을 수 없습니다."),
+	;
 
 	private final Integer code;
 	private final String message;

--- a/src/main/java/com/ajou/hertz/common/kakao/client/KakaoAuthClient.java
+++ b/src/main/java/com/ajou/hertz/common/kakao/client/KakaoAuthClient.java
@@ -1,0 +1,23 @@
+package com.ajou.hertz.common.kakao.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.ajou.hertz.common.config.feign.KakaoFeignConfig;
+import com.ajou.hertz.common.kakao.dto.request.IssueKakaoAccessTokenRequest;
+import com.ajou.hertz.common.kakao.dto.response.KakaoTokenResponse;
+
+@FeignClient(
+	name = "kakaoAuthClient",
+	url = "https://kauth.kakao.com",
+	configuration = KakaoFeignConfig.class
+)
+public interface KakaoAuthClient {
+
+	@PostMapping(
+		value = "/oauth/token",
+		headers = "Content-type=application/x-www-form-urlencoded;charset=utf-8"
+	)
+	KakaoTokenResponse issueAccessToken(@RequestBody IssueKakaoAccessTokenRequest issueTokenRequest);
+}

--- a/src/main/java/com/ajou/hertz/common/kakao/client/KakaoClient.java
+++ b/src/main/java/com/ajou/hertz/common/kakao/client/KakaoClient.java
@@ -1,0 +1,26 @@
+package com.ajou.hertz.common.kakao.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.ajou.hertz.common.config.feign.KakaoFeignConfig;
+import com.ajou.hertz.common.kakao.dto.response.KakaoUserInfoResponse;
+
+@FeignClient(
+	name = "kakaoClient",
+	url = "https://kapi.kakao.com",
+	configuration = KakaoFeignConfig.class
+)
+public interface KakaoClient {
+
+	@GetMapping(
+		value = "/v2/user/me",
+		headers = "Content-type=application/x-www-form-urlencoded;charset=utf-8"
+	)
+	KakaoUserInfoResponse getUserInfo(
+		@RequestHeader("Authorization") String authorizationHeader,
+		@RequestParam("secure_resource") Boolean secureResource
+	);
+}

--- a/src/main/java/com/ajou/hertz/common/kakao/dto/request/IssueKakaoAccessTokenRequest.java
+++ b/src/main/java/com/ajou/hertz/common/kakao/dto/request/IssueKakaoAccessTokenRequest.java
@@ -1,0 +1,18 @@
+package com.ajou.hertz.common.kakao.dto.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class IssueKakaoAccessTokenRequest {
+
+	private String grant_type;
+	private String client_id;
+	private String redirect_uri;
+	private String code;
+	private String client_secret;
+}

--- a/src/main/java/com/ajou/hertz/common/kakao/dto/response/KakaoErrorResponse.java
+++ b/src/main/java/com/ajou/hertz/common/kakao/dto/response/KakaoErrorResponse.java
@@ -1,0 +1,10 @@
+package com.ajou.hertz.common.kakao.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoErrorResponse(
+	String error,
+	@JsonProperty("error_description") String errorDescription,
+	@JsonProperty("error_code") String errorCode
+) {
+}

--- a/src/main/java/com/ajou/hertz/common/kakao/dto/response/KakaoTokenResponse.java
+++ b/src/main/java/com/ajou/hertz/common/kakao/dto/response/KakaoTokenResponse.java
@@ -1,0 +1,29 @@
+package com.ajou.hertz.common.kakao.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class KakaoTokenResponse {
+
+	@JsonProperty("token_type")
+	private String tokenType;
+
+	@JsonProperty("access_token")
+	private String accessToken;
+
+	@JsonProperty("expires_in")
+	private Integer expiresIn;
+
+	@JsonProperty("refresh_token")
+	private String refreshToken;
+
+	@JsonProperty("refresh_token_expires_in")
+	private Integer refreshTokenExpiresIn;
+}

--- a/src/main/java/com/ajou/hertz/common/kakao/dto/response/KakaoUserInfoResponse.java
+++ b/src/main/java/com/ajou/hertz/common/kakao/dto/response/KakaoUserInfoResponse.java
@@ -1,0 +1,88 @@
+package com.ajou.hertz.common.kakao.dto.response;
+
+import java.time.LocalDate;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfoResponse(
+	String id,
+	@JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+
+	public record KakaoAccount(
+		@JsonProperty("profile_image_needs_agreement") Boolean profileImageNeedsAgreement,
+		Profile profile,
+
+		@JsonProperty("has_email") Boolean hasEmail,
+		@JsonProperty("email_needs_agreement") Boolean emailNeedsAgreement,
+		@JsonProperty("is_email_valid") Boolean isEmailValid,
+		@JsonProperty("is_email_verified") Boolean isEmailVerified,
+		String email,
+
+		@JsonProperty("has_phone_number") Boolean hasPhoneNumber,
+		@JsonProperty("phone_number_needs_agreement") Boolean phoneNumberNeedsAgreement,
+		@JsonProperty("phone_number") String phoneNumber,
+
+		@JsonProperty("has_birthyear") Boolean hasBirthyear,
+		@JsonProperty("birthyear_needs_agreement") Boolean birthyearNeedsAgreement,
+		String birthyear,
+
+		@JsonProperty("has_birthday") Boolean hasBirthday,
+		String birthday,
+
+		@JsonProperty("has_gender") Boolean hasGender,
+		@JsonProperty("gender_needs_agreement") Boolean genderNeedsAgreement,
+		String gender
+	) {
+
+		public record Profile(
+			@JsonProperty("profile_image_url") String profileImageUrl,
+			@JsonProperty("thumbnail_image_url") String thumbnailImageUrl,
+			@JsonProperty("is_default_image") Boolean isDefaultImage
+		) {
+		}
+	}
+
+	public String profileImageUrl() {
+		return kakaoAccount.profile.profileImageUrl();
+	}
+
+	public String email() {
+		return kakaoAccount.email();
+	}
+
+	public String gender() {
+		return kakaoAccount.gender();
+	}
+
+	@Nullable
+	public LocalDate birth() {
+		String birthyear = kakaoAccount.birthyear();
+		String birthday = kakaoAccount.birthday();
+		if (!StringUtils.hasText(birthyear) || !StringUtils.hasText(birthday)) {
+			return null;
+		}
+		return LocalDate.of(
+			Integer.parseInt(birthyear),
+			Integer.parseInt(birthday.substring(0, 2)),
+			Integer.parseInt(birthday.substring(2, 4))
+		);
+	}
+
+	/**
+	 * <p>[한국 전화번호 형식 기준]
+	 * <p>"+82 10-1234-5678" 형태의 전화번호를 "01012345678" 형태로 변환하여 반환한다.
+	 *
+	 * @return 변환된 전화번호
+	 */
+	public String getKoreanFormatPhoneNumber() {
+		return kakaoAccount.phoneNumber()
+			.replace("+82 ", "0")
+			.replace("-", "")
+			.trim();
+	}
+}
+

--- a/src/main/java/com/ajou/hertz/common/kakao/exception/KakaoClientException.java
+++ b/src/main/java/com/ajou/hertz/common/kakao/exception/KakaoClientException.java
@@ -1,0 +1,23 @@
+package com.ajou.hertz.common.kakao.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.ajou.hertz.common.exception.CustomException;
+import com.ajou.hertz.common.exception.constant.CustomExceptionType;
+import com.ajou.hertz.common.kakao.dto.response.KakaoErrorResponse;
+
+public class KakaoClientException extends CustomException {
+
+	public KakaoClientException(HttpStatus httpStatus, KakaoErrorResponse kakaoErrorResponse) {
+		super(httpStatus, CustomExceptionType.KAKAO_CLIENT, createErrorMessage(kakaoErrorResponse));
+	}
+
+	private static String createErrorMessage(KakaoErrorResponse kakaoErrorResponse) {
+		return String.format(
+			"ErrorInfo=[errorCode=%s, error=%s, errorMessage=%s]",
+			kakaoErrorResponse.errorCode(),
+			kakaoErrorResponse.error(),
+			kakaoErrorResponse.errorDescription()
+		);
+	}
+}

--- a/src/main/java/com/ajou/hertz/common/kakao/service/KakaoService.java
+++ b/src/main/java/com/ajou/hertz/common/kakao/service/KakaoService.java
@@ -1,0 +1,75 @@
+package com.ajou.hertz.common.kakao.service;
+
+import org.springframework.stereotype.Service;
+
+import com.ajou.hertz.common.auth.JwtTokenProvider;
+import com.ajou.hertz.common.auth.dto.JwtTokenInfoDto;
+import com.ajou.hertz.common.auth.dto.request.KakaoLoginRequest;
+import com.ajou.hertz.common.kakao.client.KakaoAuthClient;
+import com.ajou.hertz.common.kakao.client.KakaoClient;
+import com.ajou.hertz.common.kakao.dto.request.IssueKakaoAccessTokenRequest;
+import com.ajou.hertz.common.kakao.dto.response.KakaoTokenResponse;
+import com.ajou.hertz.common.kakao.dto.response.KakaoUserInfoResponse;
+import com.ajou.hertz.common.kakao.exception.KakaoClientException;
+import com.ajou.hertz.common.properties.KakaoProperties;
+import com.ajou.hertz.domain.user.dto.UserDto;
+import com.ajou.hertz.domain.user.exception.UserEmailDuplicationException;
+import com.ajou.hertz.domain.user.exception.UserPhoneDuplicationException;
+import com.ajou.hertz.domain.user.service.UserCommandService;
+import com.ajou.hertz.domain.user.service.UserQueryService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class KakaoService {
+
+	private final UserQueryService userQueryService;
+	private final UserCommandService userCommandService;
+	private final KakaoClient kakaoClient;
+	private final KakaoAuthClient kakaoAuthClient;
+	private final KakaoProperties kakaoProperties;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	/**
+	 * <p>카카오에서 발급 받은 인가 코드로 유저 정보를 조회한 후, 로그인한다.
+	 * <p>만약 신규 회원이라면 신규 회원을 등록한다.
+	 *
+	 * @param kakaoLoginRequest 카카오 로그인을 위한 정보(인가코드 등)
+	 * @return 로그인 성공 시 발급한 access token 정보
+	 * @throws UserEmailDuplicationException 전달된 이메일이 중복된 이메일인 경우. 즉, 다른 사용자가 이미 같은 이메일을 사용하고 있는 경우.
+	 * @throws UserPhoneDuplicationException 전달된 전화번호가 중복된 전화번호인 경우. 즉, 다른 사용자가 이미 같은 전화번호를 사용하고 있는 경우.
+	 * @throws KakaoClientException 카카오 서버와의 통신 중 오류가 발생한 경우.
+	 */
+	public JwtTokenInfoDto login(KakaoLoginRequest kakaoLoginRequest) {
+		String kakaoAccessToken = issueAccessToken(kakaoLoginRequest);
+		KakaoUserInfoResponse userInfo = kakaoClient.getUserInfo("Bearer " + kakaoAccessToken, true);
+
+		// 기존 존재하는 회원이라면 조회, 신규 회원이라면 신규 회원 등록 로직 수행
+		UserDto user = userQueryService
+			.findDtoByKakaoUid(userInfo.id())
+			.orElseGet(() -> userCommandService.createNewUserWithKakao(userInfo));
+
+		return jwtTokenProvider.createAccessToken(user);
+	}
+
+	/**
+	 * 카카오에서 발급 받은 인가 코드로 access token을 발행한다.
+	 *
+	 * @param kakaoLoginRequest access token을 발급받기 위한 정보(인가코드 등)
+	 * @return access token
+	 * @throws KakaoClientException 카카오 서버와의 통신 중 오류가 발생한 경우.
+	 */
+	private String issueAccessToken(KakaoLoginRequest kakaoLoginRequest) {
+		KakaoTokenResponse accessTokenResponse = kakaoAuthClient.issueAccessToken(
+			new IssueKakaoAccessTokenRequest(
+				"authorization_code",
+				kakaoProperties.restApiKey(),
+				kakaoLoginRequest.getRedirectUri(),
+				kakaoLoginRequest.getAuthorizationCode(),
+				kakaoProperties.clientSecret()
+			)
+		);
+		return accessTokenResponse.getAccessToken();
+	}
+}

--- a/src/main/java/com/ajou/hertz/common/properties/KakaoProperties.java
+++ b/src/main/java/com/ajou/hertz/common/properties/KakaoProperties.java
@@ -1,0 +1,10 @@
+package com.ajou.hertz.common.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("kakao")
+public record KakaoProperties(
+	String restApiKey,
+	String clientSecret
+) {
+}

--- a/src/main/java/com/ajou/hertz/domain/user/controller/UserControllerV1.java
+++ b/src/main/java/com/ajou/hertz/domain/user/controller/UserControllerV1.java
@@ -61,7 +61,13 @@ public class UserControllerV1 {
 	)
 	@ApiResponses({
 		@ApiResponse(responseCode = "200"),
-		@ApiResponse(responseCode = "409", description = "[2200] 이미 다른 사용자가 사용 중인 이메일로 신규 회원을 등록하려고 하는 경우", content = @Content)
+		@ApiResponse(
+			responseCode = "409", content = @Content,
+			description = """
+				<p>[2200] 이미 다른 사용자가 사용 중인 이메일로 신규 회원을 등록하려고 하는 경우.
+				<p>[2203] 이미 다른 사용자가 사용 중인 전화번호로 신규 회원을 등록하려고 하는 경우.
+				"""
+		)
 	})
 	@PostMapping(headers = API_MINOR_VERSION_HEADER_NAME + "=" + 1)
 	public ResponseEntity<UserResponse> signUpV1_1(

--- a/src/main/java/com/ajou/hertz/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/ajou/hertz/domain/user/dto/request/SignUpRequest.java
@@ -2,14 +2,13 @@ package com.ajou.hertz.domain.user.dto.request;
 
 import java.time.LocalDate;
 
-import com.ajou.hertz.domain.user.constant.Gender;
 import com.ajou.hertz.common.validator.Password;
 import com.ajou.hertz.common.validator.PhoneNumber;
+import com.ajou.hertz.domain.user.constant.Gender;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -31,11 +30,9 @@ public class SignUpRequest {
 	private String password;
 
 	@Schema(description = "생년월일", example = "2024-01-01")
-	@NotNull
 	private LocalDate birth;
 
 	@Schema(description = "성별")
-	@NotNull
 	private Gender gender;
 
 	@Schema(description = "전화번호", example = "01012345678")

--- a/src/main/java/com/ajou/hertz/domain/user/entity/User.java
+++ b/src/main/java/com/ajou/hertz/domain/user/entity/User.java
@@ -62,7 +62,6 @@ public class User extends TimeTrackedBaseEntity {
 
 	private LocalDate birth;
 
-	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private Gender gender;
 
@@ -77,7 +76,7 @@ public class User extends TimeTrackedBaseEntity {
 		@NonNull String password,
 		@NonNull String profileImageUrl,
 		LocalDate birth,
-		@NonNull Gender gender,
+		Gender gender,
 		String phone
 	) {
 		return new User(

--- a/src/main/java/com/ajou/hertz/domain/user/entity/User.java
+++ b/src/main/java/com/ajou/hertz/domain/user/entity/User.java
@@ -84,4 +84,20 @@ public class User extends TimeTrackedBaseEntity {
 			profileImageUrl, birth, gender, phone, null
 		);
 	}
+
+	@NonNull
+	public static User create(
+		@NonNull String email,
+		@NonNull String password,
+		@NonNull String kakaoUid,
+		@NonNull String profileImageUrl,
+		LocalDate birth,
+		Gender gender,
+		String phone
+	) {
+		return new User(
+			null, Set.of(RoleType.USER), email, password, kakaoUid,
+			profileImageUrl, birth, gender, phone, null
+		);
+	}
 }

--- a/src/main/java/com/ajou/hertz/domain/user/exception/UserKakaoUidDuplicationException.java
+++ b/src/main/java/com/ajou/hertz/domain/user/exception/UserKakaoUidDuplicationException.java
@@ -1,0 +1,10 @@
+package com.ajou.hertz.domain.user.exception;
+
+import com.ajou.hertz.common.exception.ConflictException;
+import com.ajou.hertz.common.exception.constant.CustomExceptionType;
+
+public class UserKakaoUidDuplicationException extends ConflictException {
+	public UserKakaoUidDuplicationException(String kakaoUid) {
+		super(CustomExceptionType.USER_KAKAO_UID_DUPLICATION, "kakaoUid=" + kakaoUid);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/user/exception/UserNotFoundByKakaoUidException.java
+++ b/src/main/java/com/ajou/hertz/domain/user/exception/UserNotFoundByKakaoUidException.java
@@ -1,0 +1,10 @@
+package com.ajou.hertz.domain.user.exception;
+
+import com.ajou.hertz.common.exception.NotFoundException;
+import com.ajou.hertz.common.exception.constant.CustomExceptionType;
+
+public class UserNotFoundByKakaoUidException extends NotFoundException {
+	public UserNotFoundByKakaoUidException(String kakaoUid) {
+		super(CustomExceptionType.USER_KAKAO_UID_DUPLICATION, "kakaoUid=" + kakaoUid);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/user/exception/UserPhoneDuplicationException.java
+++ b/src/main/java/com/ajou/hertz/domain/user/exception/UserPhoneDuplicationException.java
@@ -1,0 +1,11 @@
+package com.ajou.hertz.domain.user.exception;
+
+import com.ajou.hertz.common.exception.ConflictException;
+import com.ajou.hertz.common.exception.constant.CustomExceptionType;
+
+public class UserPhoneDuplicationException extends ConflictException {
+
+	public UserPhoneDuplicationException(String phone) {
+		super(CustomExceptionType.USER_PHONE_DUPLICATION, "phone=" + phone);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ajou/hertz/domain/user/repository/UserRepository.java
@@ -10,5 +10,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
 
+	Optional<User> findByKakaoUid(String kakaoUid);
+
 	boolean existsByEmail(String email);
+
+	boolean existsByKakaoUid(String kakaoUid);
+
+	boolean existsByPhone(String phone);
 }

--- a/src/main/java/com/ajou/hertz/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/ajou/hertz/domain/user/service/UserCommandService.java
@@ -9,6 +9,8 @@ import com.ajou.hertz.domain.user.dto.UserDto;
 import com.ajou.hertz.domain.user.dto.request.SignUpRequest;
 import com.ajou.hertz.domain.user.entity.User;
 import com.ajou.hertz.domain.user.exception.UserEmailDuplicationException;
+import com.ajou.hertz.domain.user.exception.UserKakaoUidDuplicationException;
+import com.ajou.hertz.domain.user.exception.UserPhoneDuplicationException;
 import com.ajou.hertz.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -29,12 +31,12 @@ public class UserCommandService {
 	 * @param signUpRequest 회원 등록을 위한 정보가 담긴 dto
 	 * @return 새로 등록된 회원 정보가 담긴 dto
 	 * @throws UserEmailDuplicationException 전달된 이메일이 중복된 이메일인 경우. 즉, 다른 사용자가 이미 같은 이메일을 사용하고 있는 경우.
+	 * @throws UserPhoneDuplicationException 전달된 전화번호가 중복된 전화번호인 경우. 즉, 다른 사용자가 이미 같은 전화번호를 사용하고 있는 경우.
 	 */
 	public UserDto createNewUser(SignUpRequest signUpRequest) {
 		String email = signUpRequest.getEmail();
-		if (userQueryService.existsByEmail(email)) {
-			throw new UserEmailDuplicationException(email);
-		}
+		String phone = signUpRequest.getPhone();
+		validateUserNotDuplicated(email, phone);
 
 		User userSaved = userRepository.save(
 			User.create(
@@ -43,9 +45,41 @@ public class UserCommandService {
 				hertzProperties.userDefaultProfileImageUrl(),
 				signUpRequest.getBirth(),
 				signUpRequest.getGender(),
-				signUpRequest.getPhone()
+				phone
 			)
 		);
 		return UserDto.from(userSaved);
+	}
+
+	/**
+	 * 기존 유저와 중복되는 정보가 없음을 검증한다.
+	 *
+	 * @param email email
+	 * @param phone phone number
+	 * @throws UserEmailDuplicationException 전달된 이메일이 중복된 이메일인 경우. 즉, 다른 사용자가 이미 같은 이메일을 사용하고 있는 경우.
+	 * @throws UserPhoneDuplicationException 전달된 전화번호가 중복된 전화번호인 경우. 즉, 다른 사용자가 이미 같은 전화번호를 사용하고 있는 경우.
+	 */
+	private void validateUserNotDuplicated(String email, String phone) {
+		if (userQueryService.existsByEmail(email)) {
+			throw new UserEmailDuplicationException(email);
+		}
+		if (userQueryService.existsByPhone(phone)) {
+			throw new UserPhoneDuplicationException(phone);
+		}
+	}
+
+	/**
+	 * 기존 유저와 중복되는 정보가 없음을 검증한다.
+	 *
+	 * @param email email
+	 * @param phone phone number
+	 * @throws UserEmailDuplicationException 전달된 이메일이 중복된 이메일인 경우. 즉, 다른 사용자가 이미 같은 이메일을 사용하고 있는 경우.
+	 * @throws UserPhoneDuplicationException 전달된 전화번호가 중복된 전화번호인 경우. 즉, 다른 사용자가 이미 같은 전화번호를 사용하고 있는 경우.
+	 */
+	private void validateUserNotDuplicated(String email, String phone, String kakaoUid) {
+		validateUserNotDuplicated(email, phone);
+		if (userQueryService.existsByKakaoUid(kakaoUid)) {
+			throw new UserKakaoUidDuplicationException(kakaoUid);
+		}
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/ajou/hertz/domain/user/service/UserCommandService.java
@@ -1,10 +1,15 @@
 package com.ajou.hertz.domain.user.service;
 
+import java.util.UUID;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
+import com.ajou.hertz.common.kakao.dto.response.KakaoUserInfoResponse;
 import com.ajou.hertz.common.properties.HertzProperties;
+import com.ajou.hertz.domain.user.constant.Gender;
 import com.ajou.hertz.domain.user.dto.UserDto;
 import com.ajou.hertz.domain.user.dto.request.SignUpRequest;
 import com.ajou.hertz.domain.user.entity.User;
@@ -52,6 +57,36 @@ public class UserCommandService {
 	}
 
 	/**
+	 * 카카오 소셜 로그인과 연동하여, 신규 회원을 등록한다.
+	 *
+	 * @param userInfo 카카오에서 응답받은 유저 정보
+	 * @return 새로 등록된 회원 정보
+	 * @throws UserEmailDuplicationException 전달된 이메일이 중복된 이메일인 경우. 즉, 다른 사용자가 이미 같은 이메일을 사용하고 있는 경우.
+	 * @throws UserPhoneDuplicationException 전달된 전화번호가 중복된 전화번호인 경우. 즉, 다른 사용자가 이미 같은 전화번호를 사용하고 있는 경우.
+	 * @throws UserKakaoUidDuplicationException 이미 가입된 카카오 계정인 경우.
+	 */
+	public UserDto createNewUserWithKakao(KakaoUserInfoResponse userInfo) {
+		String gender = userInfo.gender();
+		String email = userInfo.email();
+		String phone = userInfo.getKoreanFormatPhoneNumber();
+		String kakaoUid = userInfo.id();
+		validateUserNotDuplicated(email, phone, kakaoUid);
+
+		User userSaved = userRepository.save(
+			User.create(
+				email,
+				passwordEncoder.encode(generateRandom16CharString()),
+				kakaoUid,
+				userInfo.profileImageUrl(),
+				userInfo.birth(),
+				StringUtils.hasText(gender) ? Gender.valueOf(gender.toUpperCase()) : null,
+				phone
+			)
+		);
+		return UserDto.from(userSaved);
+	}
+
+	/**
 	 * 기존 유저와 중복되는 정보가 없음을 검증한다.
 	 *
 	 * @param email email
@@ -81,5 +116,17 @@ public class UserCommandService {
 		if (userQueryService.existsByKakaoUid(kakaoUid)) {
 			throw new UserKakaoUidDuplicationException(kakaoUid);
 		}
+	}
+
+	/**
+	 * 16글자의 랜덤한 문자열을 생성한다.
+	 *
+	 * @return 생성된 랜덤 문자열
+	 */
+	private String generateRandom16CharString() {
+		return UUID
+			.randomUUID()
+			.toString()
+			.substring(0, 16);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/user/service/UserQueryService.java
@@ -7,6 +7,7 @@ import com.ajou.hertz.domain.user.dto.UserDto;
 import com.ajou.hertz.domain.user.entity.User;
 import com.ajou.hertz.domain.user.exception.UserNotFoundByEmailException;
 import com.ajou.hertz.domain.user.exception.UserNotFoundByIdException;
+import com.ajou.hertz.domain.user.exception.UserNotFoundByKakaoUidException;
 import com.ajou.hertz.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -62,6 +63,12 @@ public class UserQueryService {
 		return UserDto.from(getByEmail(email));
 	}
 
+	public UserDto getDtoByKakaoUid(String kakaoUid) {
+		User user = userRepository.findByKakaoUid(kakaoUid)
+			.orElseThrow(() -> new UserNotFoundByKakaoUidException(kakaoUid));
+		return UserDto.from(user);
+	}
+
 	/**
 	 * 전달된 email을 사용 중인 회원의 존재 여부를 조회한다.
 	 *
@@ -70,5 +77,25 @@ public class UserQueryService {
 	 */
 	public boolean existsByEmail(String email) {
 		return userRepository.existsByEmail(email);
+	}
+
+	/**
+	 * 전달된 kakaoUid를 사용 중인 회원의 존재 여부를 조회한다.
+	 *
+	 * @param kakaoUid kakao user id
+	 * @return 전달된 kakaoUid를 사용 중인 회원의 존재 여부
+	 */
+	public boolean existsByKakaoUid(String kakaoUid) {
+		return userRepository.existsByKakaoUid(kakaoUid);
+	}
+
+	/**
+	 * 전달된 phone를 사용 중인 회원의 존재 여부를 조회한다.
+	 *
+	 * @param phone phone number
+	 * @return 전달된 phone를 사용 중인 회원의 존재 여부
+	 */
+	public boolean existsByPhone(String phone) {
+		return userRepository.existsByPhone(phone);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/user/service/UserQueryService.java
@@ -1,5 +1,7 @@
 package com.ajou.hertz.domain.user.service;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,7 +9,6 @@ import com.ajou.hertz.domain.user.dto.UserDto;
 import com.ajou.hertz.domain.user.entity.User;
 import com.ajou.hertz.domain.user.exception.UserNotFoundByEmailException;
 import com.ajou.hertz.domain.user.exception.UserNotFoundByIdException;
-import com.ajou.hertz.domain.user.exception.UserNotFoundByKakaoUidException;
 import com.ajou.hertz.domain.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,10 @@ public class UserQueryService {
 		return userRepository.findByEmail(email).orElseThrow(() -> new UserNotFoundByEmailException(email));
 	}
 
+	public Optional<UserDto> findDtoByKakaoUid(String kakaoUid) {
+		return userRepository.findByKakaoUid(kakaoUid).map(UserDto::from);
+	}
+
 	/**
 	 * 유저 id로 유저를 조회한다.
 	 *
@@ -61,12 +66,6 @@ public class UserQueryService {
 	 */
 	public UserDto getDtoByEmail(String email) {
 		return UserDto.from(getByEmail(email));
-	}
-
-	public UserDto getDtoByKakaoUid(String kakaoUid) {
-		User user = userRepository.findByKakaoUid(kakaoUid)
-			.orElseThrow(() -> new UserNotFoundByKakaoUidException(kakaoUid));
-		return UserDto.from(user);
 	}
 
 	/**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -34,3 +34,6 @@ aws.s3.bucket-name=${AWS_S3_BUCKET_NAME}
 aws.s3.access-key=${AWS_S3_IAM_ACCESS_KEY}
 aws.s3.secret-key=${AWS_S3_IAM_SECRET_KEY}
 aws.cloud-front.base-url=${AWS_CLOUD_FRONT_BASE_URL}
+
+kakao.rest-api-key=${KAKAO_REST_API_KEY}
+kakao.client-secret=${KAKAO_CLIENT_SECRET}

--- a/src/test/java/com/ajou/hertz/unit/common/auth/controller/AuthControllerV1Test.java
+++ b/src/test/java/com/ajou/hertz/unit/common/auth/controller/AuthControllerV1Test.java
@@ -76,7 +76,7 @@ class AuthControllerV1Test {
 
 		// when & then
 		mvc.perform(
-				post("/v1/auth/login/kakao")
+				post("/v1/auth/kakao/login")
 					.header(API_MINOR_VERSION_HEADER_NAME, 1)
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(kakaoLoginRequest))

--- a/src/test/java/com/ajou/hertz/unit/common/kakao/service/KakaoServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/common/kakao/service/KakaoServiceTest.java
@@ -1,0 +1,218 @@
+package com.ajou.hertz.unit.common.kakao.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.lang.reflect.Constructor;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import com.ajou.hertz.common.auth.JwtTokenProvider;
+import com.ajou.hertz.common.auth.dto.JwtTokenInfoDto;
+import com.ajou.hertz.common.auth.dto.request.KakaoLoginRequest;
+import com.ajou.hertz.common.kakao.client.KakaoAuthClient;
+import com.ajou.hertz.common.kakao.client.KakaoClient;
+import com.ajou.hertz.common.kakao.dto.request.IssueKakaoAccessTokenRequest;
+import com.ajou.hertz.common.kakao.dto.response.KakaoTokenResponse;
+import com.ajou.hertz.common.kakao.dto.response.KakaoUserInfoResponse;
+import com.ajou.hertz.common.kakao.service.KakaoService;
+import com.ajou.hertz.common.properties.KakaoProperties;
+import com.ajou.hertz.domain.user.constant.Gender;
+import com.ajou.hertz.domain.user.constant.RoleType;
+import com.ajou.hertz.domain.user.dto.UserDto;
+import com.ajou.hertz.domain.user.service.UserCommandService;
+import com.ajou.hertz.domain.user.service.UserQueryService;
+
+@DisplayName("[Unit] Service - Kakao")
+@ExtendWith(MockitoExtension.class)
+class KakaoServiceTest {
+
+	@InjectMocks
+	private KakaoService sut;
+
+	@Mock
+	private UserQueryService userQueryService;
+
+	@Mock
+	private UserCommandService userCommandService;
+
+	@Mock
+	private KakaoClient kakaoClient;
+
+	@Mock
+	private KakaoAuthClient kakaoAuthClient;
+
+	@Mock
+	private KakaoProperties kakaoProperties;
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@BeforeTestMethod
+	public void setUp() {
+		given(kakaoProperties.restApiKey()).willReturn("kakao-rest-api-key");
+		given(kakaoProperties.clientSecret()).willReturn("kakao-client-secret");
+	}
+
+	@Test
+	void 인가_코드와_리다이렉트_주소가_주어지고_주어진_정보로_카카오_로그인을_진행한다() throws Exception {
+		// given
+		KakaoLoginRequest kakaoLoginRequest = createKakaoLoginRequest();
+		KakaoTokenResponse kakaoTokenResponse = createKakaoTokenResponse();
+		String authorizationHeaderToGettingKakaoUserInfo = "Bearer " + kakaoTokenResponse.getAccessToken();
+		KakaoUserInfoResponse kakaoUserInfoResponse = createKakaoUserInfoResponse();
+		UserDto userDto = createUserDto();
+		JwtTokenInfoDto expectedResult = createJwtTokenInfoDto();
+		given(kakaoAuthClient.issueAccessToken(any(IssueKakaoAccessTokenRequest.class))).willReturn(kakaoTokenResponse);
+		given(
+			kakaoClient.getUserInfo(authorizationHeaderToGettingKakaoUserInfo, true)
+		).willReturn(kakaoUserInfoResponse);
+		given(userQueryService.findDtoByKakaoUid(kakaoUserInfoResponse.id())).willReturn(Optional.of(userDto));
+		given(jwtTokenProvider.createAccessToken(userDto)).willReturn(expectedResult);
+
+		// when
+		JwtTokenInfoDto actualResult = sut.login(kakaoLoginRequest);
+
+		// then
+		then(kakaoProperties).should().restApiKey();
+		then(kakaoProperties).should().clientSecret();
+		then(kakaoAuthClient).should().issueAccessToken(any(IssueKakaoAccessTokenRequest.class));
+		then(kakaoClient).should().getUserInfo(authorizationHeaderToGettingKakaoUserInfo, true);
+		then(userQueryService).should().findDtoByKakaoUid(kakaoUserInfoResponse.id());
+		then(jwtTokenProvider).should().createAccessToken(userDto);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult)
+			.hasFieldOrPropertyWithValue("token", expectedResult.token());
+	}
+
+	@Test
+	void 인가_코드와_리다이렉트_주소가_주어지고_주어진_정보로_카카오_로그인을_진행한다_만약_신규_회원이라면_회원가입한다() throws Exception {
+		// given
+		KakaoLoginRequest kakaoLoginRequest = createKakaoLoginRequest();
+		KakaoTokenResponse kakaoTokenResponse = createKakaoTokenResponse();
+		String authorizationHeaderToGettingKakaoUserInfo = "Bearer " + kakaoTokenResponse.getAccessToken();
+		KakaoUserInfoResponse kakaoUserInfoResponse = createKakaoUserInfoResponse();
+		UserDto userDto = createUserDto();
+		JwtTokenInfoDto expectedResult = createJwtTokenInfoDto();
+		given(kakaoAuthClient.issueAccessToken(any(IssueKakaoAccessTokenRequest.class))).willReturn(kakaoTokenResponse);
+		given(
+			kakaoClient.getUserInfo(authorizationHeaderToGettingKakaoUserInfo, true)
+		).willReturn(kakaoUserInfoResponse);
+		given(userQueryService.findDtoByKakaoUid(kakaoUserInfoResponse.id())).willReturn(Optional.empty());
+		given(userCommandService.createNewUserWithKakao(kakaoUserInfoResponse)).willReturn(userDto);
+		given(jwtTokenProvider.createAccessToken(userDto)).willReturn(expectedResult);
+
+		// when
+		JwtTokenInfoDto actualResult = sut.login(kakaoLoginRequest);
+
+		// then
+		then(kakaoProperties).should().restApiKey();
+		then(kakaoProperties).should().clientSecret();
+		then(kakaoAuthClient).should().issueAccessToken(any(IssueKakaoAccessTokenRequest.class));
+		then(kakaoClient).should().getUserInfo(authorizationHeaderToGettingKakaoUserInfo, true);
+		then(userQueryService).should().findDtoByKakaoUid(kakaoUserInfoResponse.id());
+		then(userCommandService).should().createNewUserWithKakao(kakaoUserInfoResponse);
+		then(jwtTokenProvider).should().createAccessToken(userDto);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult)
+			.hasFieldOrPropertyWithValue("token", expectedResult.token());
+	}
+
+	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
+		then(userQueryService).shouldHaveNoMoreInteractions();
+		then(userCommandService).shouldHaveNoMoreInteractions();
+		then(kakaoClient).shouldHaveNoMoreInteractions();
+		then(kakaoAuthClient).shouldHaveNoMoreInteractions();
+		then(kakaoProperties).shouldHaveNoMoreInteractions();
+		then(jwtTokenProvider).shouldHaveNoMoreInteractions();
+	}
+
+	private UserDto createUserDto(long id) throws Exception {
+		Constructor<UserDto> userResponseConstructor = UserDto.class.getDeclaredConstructor(
+			Long.class, Set.class, String.class, String.class, String.class,
+			String.class, LocalDate.class, Gender.class, String.class, String.class
+		);
+		userResponseConstructor.setAccessible(true);
+		return userResponseConstructor.newInstance(
+			id,
+			Set.of(RoleType.USER),
+			"test@mail.com",
+			"$2a$abc123",
+			"kakao-user-id",
+			"https://user-default-profile-image",
+			LocalDate.of(2024, 1, 1),
+			Gender.ETC,
+			"01012345678",
+			"https://contack-link"
+		);
+	}
+
+	private UserDto createUserDto() throws Exception {
+		return createUserDto(1L);
+	}
+
+	private static KakaoLoginRequest createKakaoLoginRequest() throws Exception {
+		Constructor<KakaoLoginRequest> kakaoLoginRequestConstructor =
+			KakaoLoginRequest.class.getDeclaredConstructor(String.class, String.class);
+		kakaoLoginRequestConstructor.setAccessible(true);
+		return kakaoLoginRequestConstructor.newInstance(
+			"authorization-code",
+			"https://redirect-uri"
+		);
+	}
+
+	private static KakaoTokenResponse createKakaoTokenResponse() throws Exception {
+		Constructor<KakaoTokenResponse> kakaoTokenResponseConstructor = KakaoTokenResponse.class.getDeclaredConstructor(
+			String.class, String.class, Integer.class, String.class, Integer.class
+		);
+		kakaoTokenResponseConstructor.setAccessible(true);
+		return kakaoTokenResponseConstructor.newInstance("bearer", "access-token", 43199, "refresh-token", 5184000);
+	}
+
+	private static KakaoUserInfoResponse createKakaoUserInfoResponse() {
+		return new KakaoUserInfoResponse(
+			"12345",
+			new KakaoUserInfoResponse.KakaoAccount(
+				true,
+				new KakaoUserInfoResponse.KakaoAccount.Profile(
+					"https://profile-image-url",
+					"https://thumbnail-image-url",
+					true
+				),
+				true,
+				true,
+				true,
+				true,
+				"test@mail.com",
+				true,
+				true,
+				"01012345678",
+				true,
+				true,
+				null,
+				true,
+				null,
+				true,
+				true,
+				"male"
+			)
+		);
+	}
+
+	private static JwtTokenInfoDto createJwtTokenInfoDto() {
+		return new JwtTokenInfoDto(
+			"access-token",
+			LocalDateTime.of(2024, 1, 1, 0, 0)
+		);
+	}
+}

--- a/src/test/java/com/ajou/hertz/unit/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/user/service/UserCommandServiceTest.java
@@ -1,21 +1,27 @@
 package com.ajou.hertz.unit.domain.user.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.*;
 import static org.mockito.BDDMockito.*;
 
 import java.lang.reflect.Constructor;
 import java.time.LocalDate;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.event.annotation.BeforeTestMethod;
 
+import com.ajou.hertz.common.kakao.dto.response.KakaoUserInfoResponse;
 import com.ajou.hertz.common.properties.HertzProperties;
 import com.ajou.hertz.domain.user.constant.Gender;
 import com.ajou.hertz.domain.user.constant.RoleType;
@@ -23,6 +29,7 @@ import com.ajou.hertz.domain.user.dto.UserDto;
 import com.ajou.hertz.domain.user.dto.request.SignUpRequest;
 import com.ajou.hertz.domain.user.entity.User;
 import com.ajou.hertz.domain.user.exception.UserEmailDuplicationException;
+import com.ajou.hertz.domain.user.exception.UserKakaoUidDuplicationException;
 import com.ajou.hertz.domain.user.exception.UserPhoneDuplicationException;
 import com.ajou.hertz.domain.user.repository.UserRepository;
 import com.ajou.hertz.domain.user.service.UserCommandService;
@@ -58,7 +65,7 @@ class UserCommandServiceTest {
 		long userId = 1L;
 		SignUpRequest signUpRequest = createSignUpRequest();
 		String passwordEncoded = "$2a$abc123";
-		User expectedResult = createUser(userId, passwordEncoded);
+		User expectedResult = createUser(userId, passwordEncoded, "12345");
 		given(userQueryService.existsByEmail(signUpRequest.getEmail())).willReturn(false);
 		given(userQueryService.existsByPhone(signUpRequest.getPhone())).willReturn(false);
 		given(passwordEncoder.encode(signUpRequest.getPassword())).willReturn(passwordEncoded);
@@ -110,13 +117,67 @@ class UserCommandServiceTest {
 		assertThat(t).isInstanceOf(UserPhoneDuplicationException.class);
 	}
 
+	@MethodSource("testDataForCreateNewUserWithKakao")
+	@ParameterizedTest
+	void 주어진_카카오_유저_정보로_신규_회원을_등록한다(KakaoUserInfoResponse kakaoUserInfo, User expectedResult) throws Exception {
+		// given
+		given(userQueryService.existsByEmail(kakaoUserInfo.email())).willReturn(false);
+		given(userQueryService.existsByPhone(kakaoUserInfo.getKoreanFormatPhoneNumber())).willReturn(false);
+		given(userQueryService.existsByKakaoUid(kakaoUserInfo.id())).willReturn(false);
+		given(passwordEncoder.encode(anyString())).willReturn(expectedResult.getPassword());
+		given(userRepository.save(any(User.class))).willReturn(expectedResult);
+
+		// when
+		UserDto actualResult = sut.createNewUserWithKakao(kakaoUserInfo);
+
+		// then
+		then(userQueryService).should().existsByEmail(kakaoUserInfo.email());
+		then(userQueryService).should().existsByPhone(kakaoUserInfo.getKoreanFormatPhoneNumber());
+		then(userQueryService).should().existsByKakaoUid(kakaoUserInfo.id());
+		then(passwordEncoder).should().encode(anyString());
+		then(userRepository).should().save(any(User.class));
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult)
+			.hasFieldOrPropertyWithValue("id", expectedResult.getId())
+			.hasFieldOrPropertyWithValue("kakaoUid", expectedResult.getKakaoUid())
+			.hasFieldOrPropertyWithValue("password", expectedResult.getPassword());
+	}
+
+	static Stream<Arguments> testDataForCreateNewUserWithKakao() throws Exception {
+		return Stream.of(
+			arguments(createKakaoUserInfoResponse("male"), createUser(1L, "$2a$abc123", "12345", Gender.MALE)),
+			arguments(createKakaoUserInfoResponse("female"), createUser(1L, "$2a$abc123", "12345", Gender.FEMALE)),
+			arguments(createKakaoUserInfoResponse(""), createUser(1L, "$2a$abc123", "12345", null)),
+			arguments(createKakaoUserInfoResponse(null), createUser(1L, "$2a$abc123", "12345", null))
+		);
+	}
+
+	@Test
+	void 주어진_카카오_유저_정보로_신규_회원을_등록한다_이미_가입한_카카오_계정이라면_예외가_발생한다() throws Exception {
+		// given
+		KakaoUserInfoResponse kakaoUserInfo = createKakaoUserInfoResponse();
+		given(userQueryService.existsByEmail(kakaoUserInfo.email())).willReturn(false);
+		given(userQueryService.existsByPhone(kakaoUserInfo.getKoreanFormatPhoneNumber())).willReturn(false);
+		given(userQueryService.existsByKakaoUid(kakaoUserInfo.id())).willReturn(true);
+
+		// when
+		Throwable t = catchThrowable(() -> sut.createNewUserWithKakao(kakaoUserInfo));
+
+		// then
+		then(userQueryService).should().existsByEmail(kakaoUserInfo.email());
+		then(userQueryService).should().existsByPhone(kakaoUserInfo.getKoreanFormatPhoneNumber());
+		then(userQueryService).should().existsByKakaoUid(kakaoUserInfo.id());
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(t).isInstanceOf(UserKakaoUidDuplicationException.class);
+	}
+
 	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
 		then(userQueryService).shouldHaveNoMoreInteractions();
 		then(userRepository).shouldHaveNoMoreInteractions();
 		then(passwordEncoder).shouldHaveNoMoreInteractions();
 	}
 
-	private User createUser(Long id, String password) throws Exception {
+	private static User createUser(Long id, String password, String kakaoUid, Gender gender) throws Exception {
 		Constructor<User> userConstructor = User.class.getDeclaredConstructor(
 			Long.class, Set.class, String.class, String.class, String.class,
 			String.class, LocalDate.class, Gender.class, String.class, String.class
@@ -127,13 +188,17 @@ class UserCommandServiceTest {
 			Set.of(RoleType.USER),
 			"test@test.com",
 			password,
-			"kakao-user-id",
+			kakaoUid,
 			"https://user-default-profile-image-url",
 			LocalDate.of(2024, 1, 1),
-			Gender.ETC,
+			gender,
 			"010-1234-5678",
 			null
 		);
+	}
+
+	private static User createUser(Long id, String password, String kakaoUid) throws Exception {
+		return createUser(id, password, kakaoUid, Gender.ETC);
 	}
 
 	private SignUpRequest createSignUpRequest(String email, String phone) throws Exception {
@@ -152,5 +217,39 @@ class UserCommandServiceTest {
 
 	private SignUpRequest createSignUpRequest() throws Exception {
 		return createSignUpRequest("test@test.com", "01012345678");
+	}
+
+	private static KakaoUserInfoResponse createKakaoUserInfoResponse(String gender) {
+		return new KakaoUserInfoResponse(
+			"12345",
+			new KakaoUserInfoResponse.KakaoAccount(
+				true,
+				new KakaoUserInfoResponse.KakaoAccount.Profile(
+					"https://profile-image-url",
+					"https://thumbnail-image-url",
+					true
+				),
+				true,
+				true,
+				true,
+				true,
+				"test@mail.com",
+				true,
+				true,
+				"01012345678",
+				true,
+				true,
+				null,
+				true,
+				null,
+				true,
+				true,
+				gender
+			)
+		);
+	}
+
+	private static KakaoUserInfoResponse createKakaoUserInfoResponse() {
+		return createKakaoUserInfoResponse("male");
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/user/service/UserQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/user/service/UserQueryServiceTest.java
@@ -21,7 +21,6 @@ import com.ajou.hertz.domain.user.dto.UserDto;
 import com.ajou.hertz.domain.user.entity.User;
 import com.ajou.hertz.domain.user.exception.UserNotFoundByEmailException;
 import com.ajou.hertz.domain.user.exception.UserNotFoundByIdException;
-import com.ajou.hertz.domain.user.exception.UserNotFoundByKakaoUidException;
 import com.ajou.hertz.domain.user.repository.UserRepository;
 import com.ajou.hertz.domain.user.service.UserQueryService;
 
@@ -101,36 +100,22 @@ class UserQueryServiceTest {
 	}
 
 	@Test
-	void 카카오_유저_ID가_주어지고_주어진_카카오_유저_ID로_유저를_조회하면_조회된_유저_정보가_반환된다() throws Exception {
+	void 카카오_유저_ID가_주어지고_주어진_카카오_유저_ID로_유저를_조회하면_조회된_Optional_유저_정보가_반환된다() throws Exception {
 		// given
 		String kakaoUid = "12345";
 		User expectedResult = createUser(1L, "test@mail.com", kakaoUid);
 		given(userRepository.findByKakaoUid(kakaoUid)).willReturn(Optional.of(expectedResult));
 
 		// when
-		UserDto actualResult = sut.getDtoByKakaoUid(kakaoUid);
+		Optional<UserDto> actualResult = sut.findDtoByKakaoUid(kakaoUid);
 
 		// then
 		then(userRepository).should().findByKakaoUid(kakaoUid);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
-		assertThat(actualResult)
+		assertThat(actualResult).isNotEmpty();
+		assertThat(actualResult.get())
 			.hasFieldOrPropertyWithValue("id", expectedResult.getId())
 			.hasFieldOrPropertyWithValue("kakaoUid", expectedResult.getKakaoUid());
-	}
-
-	@Test
-	void 카카오_유저_ID가_주어지고_주어진_카카오_유저_ID로_유저를_조회한다_만약_일치하는_유저가_없다면_예외가_발생한다() {
-		// given
-		String kakaoUid = "12345";
-		given(userRepository.findByKakaoUid(kakaoUid)).willReturn(Optional.empty());
-
-		// when
-		Throwable t = catchThrowable(() -> sut.getDtoByKakaoUid(kakaoUid));
-
-		// then
-		then(userRepository).should().findByKakaoUid(kakaoUid);
-		verifyEveryMocksShouldHaveNoMoreInteractions();
-		assertThat(t).isInstanceOf(UserNotFoundByKakaoUidException.class);
 	}
 
 	@Test

--- a/src/test/java/com/ajou/hertz/unit/domain/user/service/UserQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/user/service/UserQueryServiceTest.java
@@ -21,6 +21,7 @@ import com.ajou.hertz.domain.user.dto.UserDto;
 import com.ajou.hertz.domain.user.entity.User;
 import com.ajou.hertz.domain.user.exception.UserNotFoundByEmailException;
 import com.ajou.hertz.domain.user.exception.UserNotFoundByIdException;
+import com.ajou.hertz.domain.user.exception.UserNotFoundByKakaoUidException;
 import com.ajou.hertz.domain.user.repository.UserRepository;
 import com.ajou.hertz.domain.user.service.UserQueryService;
 
@@ -70,7 +71,7 @@ class UserQueryServiceTest {
 	void 이메일이_주어지고_주어진_이메일로_유저를_조회하면_조회된_유저_정보가_반환된다() throws Exception {
 		// given
 		String email = "test@mail.com";
-		User expectedResult = createUser(1L, email);
+		User expectedResult = createUser(1L, email, "1234");
 		given(userRepository.findByEmail(email)).willReturn(Optional.of(expectedResult));
 
 		// when
@@ -100,7 +101,40 @@ class UserQueryServiceTest {
 	}
 
 	@Test
-	void 전달된_이메일을_사용_중인_회원의_존재_여부를_조회한다() {
+	void 카카오_유저_ID가_주어지고_주어진_카카오_유저_ID로_유저를_조회하면_조회된_유저_정보가_반환된다() throws Exception {
+		// given
+		String kakaoUid = "12345";
+		User expectedResult = createUser(1L, "test@mail.com", kakaoUid);
+		given(userRepository.findByKakaoUid(kakaoUid)).willReturn(Optional.of(expectedResult));
+
+		// when
+		UserDto actualResult = sut.getDtoByKakaoUid(kakaoUid);
+
+		// then
+		then(userRepository).should().findByKakaoUid(kakaoUid);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult)
+			.hasFieldOrPropertyWithValue("id", expectedResult.getId())
+			.hasFieldOrPropertyWithValue("kakaoUid", expectedResult.getKakaoUid());
+	}
+
+	@Test
+	void 카카오_유저_ID가_주어지고_주어진_카카오_유저_ID로_유저를_조회한다_만약_일치하는_유저가_없다면_예외가_발생한다() {
+		// given
+		String kakaoUid = "12345";
+		given(userRepository.findByKakaoUid(kakaoUid)).willReturn(Optional.empty());
+
+		// when
+		Throwable t = catchThrowable(() -> sut.getDtoByKakaoUid(kakaoUid));
+
+		// then
+		then(userRepository).should().findByKakaoUid(kakaoUid);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(t).isInstanceOf(UserNotFoundByKakaoUidException.class);
+	}
+
+	@Test
+	void 이메일이_주어지고_주어진_이메일을_사용_중인_회원의_존재_여부를_조회한다() {
 		// given
 		String email = "test@test.com";
 		boolean expectedResult = true;
@@ -115,11 +149,43 @@ class UserQueryServiceTest {
 		assertThat(actualResult).isEqualTo(expectedResult);
 	}
 
+	@Test
+	void 전화번호가_주어지고_주어진_전화번호를_사용_중인_회원의_존재_여부를_조회한다() {
+		// given
+		String phone = "01012345678";
+		boolean expectedResult = true;
+		given(userRepository.existsByPhone(phone)).willReturn(expectedResult);
+
+		// when
+		boolean actualResult = sut.existsByPhone(phone);
+
+		// then
+		then(userRepository).should().existsByPhone(phone);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult).isEqualTo(expectedResult);
+	}
+
+	@Test
+	void 카카오_유저_ID가_주어지고_주어진_ID를_사용_중인_회원의_존재_여부를_조회한다() {
+		// given
+		String kakaoUid = "1234";
+		boolean expectedResult = true;
+		given(userRepository.existsByKakaoUid(kakaoUid)).willReturn(expectedResult);
+
+		// when
+		boolean actualResult = sut.existsByKakaoUid(kakaoUid);
+
+		// then
+		then(userRepository).should().existsByKakaoUid(kakaoUid);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult).isEqualTo(expectedResult);
+	}
+
 	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
 		then(userRepository).shouldHaveNoMoreInteractions();
 	}
 
-	private User createUser(Long id, String email) throws Exception {
+	private User createUser(Long id, String email, String kakaoUid) throws Exception {
 		Constructor<User> userConstructor = User.class.getDeclaredConstructor(
 			Long.class, Set.class, String.class, String.class, String.class,
 			String.class, LocalDate.class, Gender.class, String.class, String.class
@@ -130,16 +196,16 @@ class UserQueryServiceTest {
 			Set.of(RoleType.USER),
 			email,
 			"password",
-			"kakao-user-id",
+			kakaoUid,
 			"https://user-default-profile-image-url",
 			LocalDate.of(2024, 1, 1),
 			Gender.ETC,
-			"010-1234-5678",
+			"01012345678",
 			null
 		);
 	}
 
 	private User createUser(Long id) throws Exception {
-		return createUser(id, "test@mail.com");
+		return createUser(id, "test@mail.com", "12345");
 	}
 }


### PR DESCRIPTION
## 🔥 Related Issue
- Close #25

## 🏃‍ Task
- 외부 서버와의 API communication을 위해 Spring Open Feign (Feign Client) 의존성 추가
- 카카오 로그인 API 구현
  - 카카오 로그인 시, 기존 회원이라면 회원 정보를 바탕으로 access token 발급
  - 카카오 로그인 시, 신규 회원이라면 회원가입(신규 회원 등록) 진행 후 해당 유저 정보로 access token 발급

## 📄 Reference
- [Spring Open Feign 4.1.0 공식문서](https://docs.spring.io/spring-cloud-openfeign/reference/index.html)
- [우아한형제들 기술블로그 - 우아한 feign 적용기](https://techblog.woowahan.com/2630/)
- [Velog - Feign client 적용기](https://velog.io/@haron/Feign-client-%EC%A0%81%EC%9A%A9%EA%B8%B0)
- [Velog - Spring Feign Client 적용하기](https://velog.io/@supway/%EC%8A%A4%ED%94%84%EB%A7%81-Feign-Client-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0-1#resttemplete-vs-feign-client)
- [Stack Overflow - Feign Client Dynamic Authorization Header](https://stackoverflow.com/questions/50163525/feign-client-dynamic-authorization-header)
- [Baeldung - Post form-url-encoded Data with Spring Cloud Feign](https://www.baeldung.com/spring-cloud-post-form-url-encoded-data)
