### PR TITLE
베이스 기타 매물 생성 API 구현

### DIFF
--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentControllerV1.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentControllerV1.java
@@ -14,8 +14,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ajou.hertz.common.auth.UserPrincipal;
+import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
+import com.ajou.hertz.domain.instrument.dto.response.BassGuitarResponse;
 import com.ajou.hertz.domain.instrument.dto.response.ElectricGuitarResponse;
 import com.ajou.hertz.domain.instrument.service.InstrumentCommandService;
 
@@ -44,7 +47,7 @@ public class InstrumentControllerV1 {
 		headers = API_MINOR_VERSION_HEADER_NAME + "=" + 1,
 		consumes = MediaType.MULTIPART_FORM_DATA_VALUE
 	)
-	public ResponseEntity<ElectricGuitarResponse> createNewInstrumentV1_1(
+	public ResponseEntity<ElectricGuitarResponse> createNewElectricGuitarV1_1(
 		@AuthenticationPrincipal UserPrincipal userPrincipal,
 		@ParameterObject @ModelAttribute @Valid CreateNewElectricGuitarRequest createNewElectricGuitarRequest
 	) {
@@ -55,5 +58,30 @@ public class InstrumentControllerV1 {
 		return ResponseEntity
 			.created(URI.create("/instruments/" + electricGuitar.getId()))
 			.body(ElectricGuitarResponse.from(electricGuitar));
+	}
+
+	@Operation(
+		summary = "베이스 기타 매물 등록",
+		description = """
+			<p>베이스 기타 매물을 등록합니다.
+			<p>요청 시 <strong>multipart/form-data</strong> content-type으로 요쳥해야 합니다.
+			"""
+	)
+	@PostMapping(
+		value = "/bass-guitars",
+		headers = API_MINOR_VERSION_HEADER_NAME + "=" + 1,
+		consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+	)
+	public ResponseEntity<BassGuitarResponse> createNewBassGuitarV1_1(
+		@AuthenticationPrincipal UserPrincipal userPrincipal,
+		@ParameterObject @ModelAttribute @Valid CreateNewBassGuitarRequest createNewBassGuitarRequest
+	) {
+		BassGuitarDto bassGuitar = instrumentCommandService.createNewBassGuitar(
+			userPrincipal.getUserId(),
+			createNewBassGuitarRequest
+		);
+		return ResponseEntity
+			.created(URI.create("/instruments/" + bassGuitar.getId()))
+			.body(BassGuitarResponse.from(bassGuitar));
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/BassGuitarDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/BassGuitarDto.java
@@ -1,0 +1,74 @@
+package com.ajou.hertz.domain.instrument.dto;
+
+import java.util.List;
+
+import com.ajou.hertz.common.dto.AddressDto;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.GuitarColor;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.user.dto.UserDto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class BassGuitarDto extends InstrumentDto {
+
+	private BassGuitarBrand brand;
+	private BassGuitarPickUp pickUp;
+	private BassGuitarPreAmplifier preAmplifier;
+	private GuitarColor color;
+
+	private BassGuitarDto(
+		Long id,
+		UserDto seller,
+		String title,
+		InstrumentProgressStatus progressStatus,
+		AddressDto tradeAddress,
+		Short qualityStatus,
+		Integer price,
+		Boolean hasAnomaly,
+		String description,
+		List<InstrumentImageDto> images,
+		List<String> hashtags,
+		BassGuitarBrand brand,
+		BassGuitarPickUp pickUp,
+		BassGuitarPreAmplifier preAmplifier,
+		GuitarColor color
+	) {
+		super(
+			id, seller, title, progressStatus, tradeAddress, qualityStatus,
+			price, hasAnomaly, description, images, hashtags
+		);
+		this.brand = brand;
+		this.pickUp = pickUp;
+		this.preAmplifier = preAmplifier;
+		this.color = color;
+	}
+
+	public static BassGuitarDto from(BassGuitar bassGuitar) {
+		InstrumentDto instrumentDto = InstrumentDto.from(bassGuitar);
+		return new BassGuitarDto(
+			instrumentDto.getId(),
+			instrumentDto.getSeller(),
+			instrumentDto.getTitle(),
+			instrumentDto.getProgressStatus(),
+			instrumentDto.getTradeAddress(),
+			instrumentDto.getQualityStatus(),
+			instrumentDto.getPrice(),
+			instrumentDto.getHasAnomaly(),
+			instrumentDto.getDescription(),
+			instrumentDto.getImages(),
+			instrumentDto.getHashtags(),
+			bassGuitar.getBrand(),
+			bassGuitar.getPickUp(),
+			bassGuitar.getPreAmplifier(),
+			bassGuitar.getColor()
+		);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/ElectricGuitarDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/ElectricGuitarDto.java
@@ -11,48 +11,63 @@ import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.user.dto.UserDto;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class ElectricGuitarDto {
+public class ElectricGuitarDto extends InstrumentDto {
 
-	private Long id;
-	private UserDto seller;
-	private String title;
-	private InstrumentProgressStatus progressStatus;
-	private AddressDto tradeAddress;
-	private Short qualityStatus;
-	private Integer price;
-	private Boolean hasAnomaly;
-	private String description;
 	private ElectricGuitarBrand brand;
 	private ElectricGuitarModel model;
 	private Short productionYear;
 	private GuitarColor color;
-	private List<InstrumentImageDto> images;
-	private List<String> hashtags;
+
+	private ElectricGuitarDto(
+		Long id,
+		UserDto seller,
+		String title,
+		InstrumentProgressStatus progressStatus,
+		AddressDto tradeAddress,
+		Short qualityStatus,
+		Integer price,
+		Boolean hasAnomaly,
+		String description,
+		ElectricGuitarBrand brand,
+		ElectricGuitarModel model,
+		Short productionYear,
+		GuitarColor color,
+		List<InstrumentImageDto> images,
+		List<String> hashtags
+	) {
+		super(
+			id, seller, title, progressStatus, tradeAddress, qualityStatus,
+			price, hasAnomaly, description, images, hashtags
+		);
+		this.brand = brand;
+		this.model = model;
+		this.productionYear = productionYear;
+		this.color = color;
+	}
 
 	public static ElectricGuitarDto from(ElectricGuitar electricGuitar) {
+		InstrumentDto instrumentDto = InstrumentDto.from(electricGuitar);
 		return new ElectricGuitarDto(
-			electricGuitar.getId(),
-			UserDto.from(electricGuitar.getSeller()),
-			electricGuitar.getTitle(),
-			electricGuitar.getProgressStatus(),
-			AddressDto.from(electricGuitar.getTradeAddress()),
-			electricGuitar.getQualityStatus(),
-			electricGuitar.getPrice(),
-			electricGuitar.getHasAnomaly(),
-			electricGuitar.getDescription(),
+			instrumentDto.getId(),
+			instrumentDto.getSeller(),
+			instrumentDto.getTitle(),
+			instrumentDto.getProgressStatus(),
+			instrumentDto.getTradeAddress(),
+			instrumentDto.getQualityStatus(),
+			instrumentDto.getPrice(),
+			instrumentDto.getHasAnomaly(),
+			instrumentDto.getDescription(),
 			electricGuitar.getBrand(),
 			electricGuitar.getModel(),
 			electricGuitar.getProductionYear(),
 			electricGuitar.getColor(),
-			electricGuitar.getImages().toDtos(),
-			electricGuitar.getHashtags().toStrings()
+			instrumentDto.getImages(),
+			instrumentDto.getHashtags()
 		);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/InstrumentDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/InstrumentDto.java
@@ -1,0 +1,47 @@
+package com.ajou.hertz.domain.instrument.dto;
+
+import java.util.List;
+
+import com.ajou.hertz.common.dto.AddressDto;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.user.dto.UserDto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class InstrumentDto {
+
+	private Long id;
+	private UserDto seller;
+	private String title;
+	private InstrumentProgressStatus progressStatus;
+	private AddressDto tradeAddress;
+	private Short qualityStatus;
+	private Integer price;
+	private Boolean hasAnomaly;
+	private String description;
+	private List<InstrumentImageDto> images;
+	private List<String> hashtags;
+
+	public static InstrumentDto from(Instrument instrument) {
+		return new InstrumentDto(
+			instrument.getId(),
+			UserDto.from(instrument.getSeller()),
+			instrument.getTitle(),
+			instrument.getProgressStatus(),
+			AddressDto.from(instrument.getTradeAddress()),
+			instrument.getQualityStatus(),
+			instrument.getPrice(),
+			instrument.getHasAnomaly(),
+			instrument.getDescription(),
+			instrument.getImages().toDtos(),
+			instrument.getHashtags().toStrings()
+		);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewBassGuitarRequest.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewBassGuitarRequest.java
@@ -1,0 +1,77 @@
+package com.ajou.hertz.domain.instrument.dto.request;
+
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ajou.hertz.common.dto.request.AddressRequest;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.GuitarColor;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.user.entity.User;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter    // for multipart/form-data with @ModelAttribute
+@Getter
+public class CreateNewBassGuitarRequest extends CreateNewInstrumentRequest<BassGuitar> {
+
+	@NotNull
+	private BassGuitarBrand brand;
+
+	@NotNull
+	private BassGuitarPickUp pickUp;
+
+	@NotNull
+	private BassGuitarPreAmplifier preAmplifier;
+
+	@NotNull
+	private GuitarColor color;
+
+	private CreateNewBassGuitarRequest(
+		String title,
+		InstrumentProgressStatus progressStatus,
+		AddressRequest tradeAddress,
+		Short qualityStatus,
+		Integer price,
+		Boolean hasAnomaly,
+		String description,
+		List<MultipartFile> images,
+		List<String> hashtags,
+		BassGuitarBrand brand,
+		BassGuitarPickUp pickUp,
+		BassGuitarPreAmplifier preAmplifier,
+		GuitarColor color
+	) {
+		super(title, progressStatus, tradeAddress, qualityStatus, price, hasAnomaly, description, images, hashtags);
+		this.brand = brand;
+		this.pickUp = pickUp;
+		this.preAmplifier = preAmplifier;
+		this.color = color;
+	}
+
+	public BassGuitar toEntity(User seller) {
+		return BassGuitar.create(
+			seller,
+			getTitle(),
+			getProgressStatus(),
+			getTradeAddress().toEntity(),
+			getQualityStatus(),
+			getPrice(),
+			getHasAnomaly(),
+			getDescription(),
+			getBrand(),
+			getPickUp(),
+			getPreAmplifier(),
+			getColor()
+		);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewElectricGuitarRequest.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewElectricGuitarRequest.java
@@ -2,7 +2,6 @@ package com.ajou.hertz.domain.instrument.dto.request;
 
 import java.util.List;
 
-import org.hibernate.validator.constraints.Length;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.ajou.hertz.common.dto.request.AddressRequest;
@@ -14,56 +13,16 @@ import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.user.entity.User;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Setter    // for multipart/form-data with @ModelAttribute
 @Getter
-public class CreateNewElectricGuitarRequest {
-
-	@Schema(description = "제목", example = "펜더 로드원 텔레캐스터")
-	@NotBlank
-	private String title;
-
-	@Schema(description = "악기 사진")
-	@NotNull
-	@Size(min = 4, max = 7)
-	private List<MultipartFile> images;
-
-	@NotNull
-	private InstrumentProgressStatus progressStatus;
-
-	@Schema(description = "거래 장소")
-	@NotNull
-	private AddressRequest tradeAddress;
-
-	@Schema(description = "악기 상태. 1~5 단계로 구성됩니다.", example = "3")
-	@NotNull
-	@Min(1)
-	@Max(5)
-	private Short qualityStatus;
-
-	@Schema(description = "가격", example = "527000")
-	@NotNull
-	private Integer price;
-
-	@Schema(description = "특이사항 유무", example = "true")
-	@NotNull
-	private Boolean hasAnomaly;
-
-	@Schema(description = "특이사항 및 상세 설명. 내용이 없을 경우에는 빈 문자열로 요청하면 됩니다.", example = "14년 시리얼 펜더 로드원 50 텔레입니다. 기존 ...")
-	@NotNull
-	private String description;
+public class CreateNewElectricGuitarRequest extends CreateNewInstrumentRequest {
 
 	@NotNull
 	private ElectricGuitarBrand brand;
@@ -78,23 +37,42 @@ public class CreateNewElectricGuitarRequest {
 	@NotNull
 	private GuitarColor color;
 
-	@Schema(description = "해시태그(각 해시태그마다 최대 10글자)", example = "[\"펜더\", \"Fender\"]")
-	private List<@NotBlank @Length(max = 10) String> hashtags;
+	private CreateNewElectricGuitarRequest(
+		String title,
+		List<MultipartFile> images,
+		InstrumentProgressStatus progressStatus,
+		AddressRequest tradeAddress,
+		Short qualityStatus,
+		Integer price,
+		Boolean hasAnomaly,
+		String description,
+		ElectricGuitarBrand brand,
+		ElectricGuitarModel model,
+		Short productionYear,
+		GuitarColor color,
+		List<String> hashtags
+	) {
+		super(title, progressStatus, tradeAddress, qualityStatus, price, hasAnomaly, description, images, hashtags);
+		this.brand = brand;
+		this.model = model;
+		this.productionYear = productionYear;
+		this.color = color;
+	}
 
 	public ElectricGuitar toEntity(User seller) {
 		return ElectricGuitar.create(
 			seller,
-			title,
-			progressStatus,
-			tradeAddress.toEntity(),
-			qualityStatus,
-			price,
-			hasAnomaly,
-			description,
-			brand,
-			model,
-			productionYear,
-			color
+			getTitle(),
+			getProgressStatus(),
+			getTradeAddress().toEntity(),
+			getQualityStatus(),
+			getPrice(),
+			getHasAnomaly(),
+			getDescription(),
+			getBrand(),
+			getModel(),
+			getProductionYear(),
+			getColor()
 		);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewElectricGuitarRequest.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewElectricGuitarRequest.java
@@ -22,7 +22,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Setter    // for multipart/form-data with @ModelAttribute
 @Getter
-public class CreateNewElectricGuitarRequest extends CreateNewInstrumentRequest {
+public class CreateNewElectricGuitarRequest extends CreateNewInstrumentRequest<ElectricGuitar> {
 
 	@NotNull
 	private ElectricGuitarBrand brand;

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewInstrumentRequest.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewInstrumentRequest.java
@@ -1,0 +1,65 @@
+package com.ajou.hertz.domain.instrument.dto.request;
+
+import java.util.List;
+
+import org.hibernate.validator.constraints.Length;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ajou.hertz.common.dto.request.AddressRequest;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter    // for multipart/form-data with @ModelAttribute
+@Getter
+public abstract class CreateNewInstrumentRequest {
+
+	@Schema(description = "제목", example = "펜더 로드원 텔레캐스터")
+	@NotBlank
+	private String title;
+
+	@NotNull
+	private InstrumentProgressStatus progressStatus;
+
+	@Schema(description = "거래 장소")
+	@NotNull
+	private AddressRequest tradeAddress;
+
+	@Schema(description = "악기 상태. 1~5 단계로 구성됩니다.", example = "3")
+	@NotNull
+	@Min(1)
+	@Max(5)
+	private Short qualityStatus;
+
+	@Schema(description = "가격", example = "527000")
+	@NotNull
+	private Integer price;
+
+	@Schema(description = "특이사항 유무", example = "true")
+	@NotNull
+	private Boolean hasAnomaly;
+
+	@Schema(description = "특이사항 및 상세 설명. 내용이 없을 경우에는 빈 문자열로 요청하면 됩니다.", example = "14년 시리얼 펜더 로드원 50 텔레입니다. 기존 ...")
+	@NotNull
+	private String description;
+
+	@Schema(description = "악기 사진")
+	@NotNull
+	@Size(min = 4, max = 7)
+	private List<MultipartFile> images;
+
+	@Schema(description = "해시태그(각 해시태그마다 최대 10글자)", example = "[\"펜더\", \"Fender\"]")
+	private List<@NotBlank @Length(max = 10) String> hashtags;
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewInstrumentRequest.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/CreateNewInstrumentRequest.java
@@ -7,6 +7,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.ajou.hertz.common.dto.request.AddressRequest;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.user.entity.User;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
@@ -24,7 +26,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Setter    // for multipart/form-data with @ModelAttribute
 @Getter
-public abstract class CreateNewInstrumentRequest {
+public abstract class CreateNewInstrumentRequest<T extends Instrument> {
 
 	@Schema(description = "제목", example = "펜더 로드원 텔레캐스터")
 	@NotBlank
@@ -62,4 +64,6 @@ public abstract class CreateNewInstrumentRequest {
 
 	@Schema(description = "해시태그(각 해시태그마다 최대 10글자)", example = "[\"펜더\", \"Fender\"]")
 	private List<@NotBlank @Length(max = 10) String> hashtags;
+
+	public abstract T toEntity(User seller);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/BassGuitarResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/BassGuitarResponse.java
@@ -1,0 +1,81 @@
+package com.ajou.hertz.domain.instrument.dto.response;
+
+import java.util.List;
+
+import com.ajou.hertz.common.dto.response.AddressResponse;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.GuitarColor;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class BassGuitarResponse extends InstrumentResponse {
+
+	@Schema(description = "브랜드")
+	private BassGuitarBrand brand;
+
+	@Schema(description = "픽업 종류")
+	private BassGuitarPickUp pickUp;
+
+	@Schema(description = "프리앰프 종류")
+	private BassGuitarPreAmplifier preAmplifier;
+
+	@Schema(description = "색상")
+	private GuitarColor color;
+
+	public BassGuitarResponse(
+		Long id,
+		Long sellerId,
+		String title,
+		InstrumentProgressStatus progressStatus,
+		AddressResponse tradeAddress,
+		Short qualityStatus,
+		Integer price,
+		Boolean hasAnomaly,
+		String description,
+		List<InstrumentImageResponse> images,
+		List<String> hashtags,
+		BassGuitarBrand brand,
+		BassGuitarPickUp pickUp,
+		BassGuitarPreAmplifier preAmplifier,
+		GuitarColor color
+	) {
+		super(
+			id, sellerId, title, progressStatus, tradeAddress, qualityStatus,
+			price, hasAnomaly, description, images, hashtags
+		);
+		this.brand = brand;
+		this.pickUp = pickUp;
+		this.preAmplifier = preAmplifier;
+		this.color = color;
+	}
+
+	public static BassGuitarResponse from(BassGuitarDto bassGuitarDto) {
+		InstrumentResponse instrumentResponse = InstrumentResponse.from(bassGuitarDto);
+		return new BassGuitarResponse(
+			instrumentResponse.getId(),
+			instrumentResponse.getSellerId(),
+			instrumentResponse.getTitle(),
+			instrumentResponse.getProgressStatus(),
+			instrumentResponse.getTradeAddress(),
+			instrumentResponse.getQualityStatus(),
+			instrumentResponse.getPrice(),
+			instrumentResponse.getHasAnomaly(),
+			instrumentResponse.getDescription(),
+			instrumentResponse.getImages(),
+			instrumentResponse.getHashtags(),
+			bassGuitarDto.getBrand(),
+			bassGuitarDto.getPickUp(),
+			bassGuitarDto.getPreAmplifier(),
+			bassGuitarDto.getColor()
+		);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/ElectricGuitarResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/ElectricGuitarResponse.java
@@ -11,41 +11,12 @@ import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
-public class ElectricGuitarResponse {
-
-	@Schema(description = "Id of instrument(electric guitar)", example = "2")
-	private Long id;
-
-	@Schema(description = "Id of seller", example = "1")
-	private Long sellerId;
-
-	@Schema(description = "제목", example = "펜더 로드원 텔레캐스터")
-	private String title;
-
-	@Schema(description = "매물 진행 상태")
-	private InstrumentProgressStatus progressStatus;
-
-	@Schema(description = "거래 장소")
-	private AddressResponse tradeAddress;
-
-	@Schema(description = "악기 상태. 1~5의 값을 갖습니다.", example = "3")
-	private Short qualityStatus;
-
-	@Schema(description = "가격", example = "527000")
-	private Integer price;
-
-	@Schema(description = "특이사항 유무", example = "true")
-	private Boolean hasAnomaly;
-
-	@Schema(description = "특이사항 및 상세 설명. 내용이 없을 경우에는 빈 문자열로 요청하면 됩니다.", example = "14년 시리얼 펜더 로드원 50 텔레입니다. 기존 ...")
-	private String description;
+public class ElectricGuitarResponse extends InstrumentResponse {
 
 	@Schema(description = "브랜드")
 	private ElectricGuitarBrand brand;
@@ -59,32 +30,50 @@ public class ElectricGuitarResponse {
 	@Schema(description = "색상")
 	private GuitarColor color;
 
-	@Schema(description = "악기 이미지")
-	private List<InstrumentImageResponse> images;
-
-	@Schema(description = "해시태그", example = "[\"펜더\", \"Fender\"]")
-	private List<String> hashtags;
+	private ElectricGuitarResponse(
+		Long id,
+		Long sellerId,
+		String title,
+		InstrumentProgressStatus progressStatus,
+		AddressResponse tradeAddress,
+		Short qualityStatus,
+		Integer price,
+		Boolean hasAnomaly,
+		String description,
+		List<InstrumentImageResponse> images,
+		List<String> hashtags,
+		ElectricGuitarBrand brand,
+		ElectricGuitarModel model,
+		Short productionYear,
+		GuitarColor color
+	) {
+		super(
+			id, sellerId, title, progressStatus, tradeAddress, qualityStatus,
+			price, hasAnomaly, description, images, hashtags);
+		this.brand = brand;
+		this.model = model;
+		this.productionYear = productionYear;
+		this.color = color;
+	}
 
 	public static ElectricGuitarResponse from(ElectricGuitarDto electricGuitarDto) {
+		InstrumentResponse instrumentResponse = InstrumentResponse.from(electricGuitarDto);
 		return new ElectricGuitarResponse(
-			electricGuitarDto.getId(),
-			electricGuitarDto.getSeller().getId(),
-			electricGuitarDto.getTitle(),
-			electricGuitarDto.getProgressStatus(),
-			AddressResponse.from(electricGuitarDto.getTradeAddress()),
-			electricGuitarDto.getQualityStatus(),
-			electricGuitarDto.getPrice(),
-			electricGuitarDto.getHasAnomaly(),
-			electricGuitarDto.getDescription(),
+			instrumentResponse.getId(),
+			instrumentResponse.getSellerId(),
+			instrumentResponse.getTitle(),
+			instrumentResponse.getProgressStatus(),
+			instrumentResponse.getTradeAddress(),
+			instrumentResponse.getQualityStatus(),
+			instrumentResponse.getPrice(),
+			instrumentResponse.getHasAnomaly(),
+			instrumentResponse.getDescription(),
+			instrumentResponse.getImages(),
+			instrumentResponse.getHashtags(),
 			electricGuitarDto.getBrand(),
 			electricGuitarDto.getModel(),
 			electricGuitarDto.getProductionYear(),
-			electricGuitarDto.getColor(),
-			electricGuitarDto.getImages()
-				.stream()
-				.map(InstrumentImageResponse::from)
-				.toList(),
-			electricGuitarDto.getHashtags()
+			electricGuitarDto.getColor()
 		);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/InstrumentResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/InstrumentResponse.java
@@ -1,0 +1,71 @@
+package com.ajou.hertz.domain.instrument.dto.response;
+
+import java.util.List;
+
+import com.ajou.hertz.common.dto.response.AddressResponse;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class InstrumentResponse {
+
+	@Schema(description = "Id of instrument(electric guitar)", example = "2")
+	private Long id;
+
+	@Schema(description = "Id of seller", example = "1")
+	private Long sellerId;
+
+	@Schema(description = "제목", example = "펜더 로드원 텔레캐스터")
+	private String title;
+
+	@Schema(description = "매물 진행 상태")
+	private InstrumentProgressStatus progressStatus;
+
+	@Schema(description = "거래 장소")
+	private AddressResponse tradeAddress;
+
+	@Schema(description = "악기 상태. 1~5의 값을 갖습니다.", example = "3")
+	private Short qualityStatus;
+
+	@Schema(description = "가격", example = "527000")
+	private Integer price;
+
+	@Schema(description = "특이사항 유무", example = "true")
+	private Boolean hasAnomaly;
+
+	@Schema(description = "특이사항 및 상세 설명. 내용이 없을 경우에는 빈 문자열로 요청하면 됩니다.", example = "14년 시리얼 펜더 로드원 50 텔레입니다. 기존 ...")
+	private String description;
+
+	@Schema(description = "악기 이미지")
+	private List<InstrumentImageResponse> images;
+
+	@Schema(description = "해시태그", example = "[\"펜더\", \"Fender\"]")
+	private List<String> hashtags;
+
+	public static InstrumentResponse from(InstrumentDto instrumentDto) {
+		return new InstrumentResponse(
+			instrumentDto.getId(),
+			instrumentDto.getSeller().getId(),
+			instrumentDto.getTitle(),
+			instrumentDto.getProgressStatus(),
+			AddressResponse.from(instrumentDto.getTradeAddress()),
+			instrumentDto.getQualityStatus(),
+			instrumentDto.getPrice(),
+			instrumentDto.getHasAnomaly(),
+			instrumentDto.getDescription(),
+			instrumentDto.getImages()
+				.stream()
+				.map(InstrumentImageResponse::from)
+				.toList(),
+			instrumentDto.getHashtags()
+		);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentCommandService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentCommandService.java
@@ -7,9 +7,12 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.ajou.hertz.common.file.service.FileService;
+import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewInstrumentRequest;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.ajou.hertz.domain.instrument.entity.InstrumentHashtag;
@@ -17,6 +20,7 @@ import com.ajou.hertz.domain.instrument.entity.InstrumentImage;
 import com.ajou.hertz.domain.instrument.repository.InstrumentHashtagRepository;
 import com.ajou.hertz.domain.instrument.repository.InstrumentImageRepository;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
+import com.ajou.hertz.domain.instrument.strategy.BassGuitarCreationStrategy;
 import com.ajou.hertz.domain.instrument.strategy.ElectricGuitarCreationStrategy;
 import com.ajou.hertz.domain.instrument.strategy.InstrumentCreationStrategy;
 import com.ajou.hertz.domain.user.entity.User;
@@ -40,6 +44,11 @@ public class InstrumentCommandService {
 	public ElectricGuitarDto createNewElectricGuitar(Long sellerId, CreateNewElectricGuitarRequest request) {
 		ElectricGuitar electricGuitar = createNewInstrument(sellerId, request, new ElectricGuitarCreationStrategy());
 		return ElectricGuitarDto.from(electricGuitar);
+	}
+
+	public BassGuitarDto createNewBassGuitar(Long sellerId, CreateNewBassGuitarRequest request) {
+		BassGuitar bassGuitar = createNewInstrument(sellerId, request, new BassGuitarCreationStrategy());
+		return BassGuitarDto.from(bassGuitar);
 	}
 
 	private <T extends Instrument, U extends CreateNewInstrumentRequest<T>> T createNewInstrument(

--- a/src/main/java/com/ajou/hertz/domain/instrument/strategy/BassGuitarCreationStrategy.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/strategy/BassGuitarCreationStrategy.java
@@ -1,0 +1,13 @@
+package com.ajou.hertz.domain.instrument.strategy;
+
+import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.user.entity.User;
+
+public class BassGuitarCreationStrategy implements InstrumentCreationStrategy<BassGuitar, CreateNewBassGuitarRequest> {
+
+	@Override
+	public BassGuitar createInstrument(User seller, CreateNewBassGuitarRequest request) {
+		return request.toEntity(seller);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/strategy/ElectricGuitarCreationStrategy.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/strategy/ElectricGuitarCreationStrategy.java
@@ -1,0 +1,14 @@
+package com.ajou.hertz.domain.instrument.strategy;
+
+import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
+import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
+import com.ajou.hertz.domain.user.entity.User;
+
+public class ElectricGuitarCreationStrategy
+	implements InstrumentCreationStrategy<ElectricGuitar, CreateNewElectricGuitarRequest> {
+
+	@Override
+	public ElectricGuitar createInstrument(User seller, CreateNewElectricGuitarRequest request) {
+		return request.toEntity(seller);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/strategy/InstrumentCreationStrategy.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/strategy/InstrumentCreationStrategy.java
@@ -1,0 +1,10 @@
+package com.ajou.hertz.domain.instrument.strategy;
+
+import com.ajou.hertz.domain.instrument.dto.request.CreateNewInstrumentRequest;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.user.entity.User;
+
+public interface InstrumentCreationStrategy<T extends Instrument, U extends CreateNewInstrumentRequest<T>> {
+
+	T createInstrument(User seller, U request);
+}

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerV1Test.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerV1Test.java
@@ -182,10 +182,11 @@ class InstrumentControllerV1Test {
 	}
 
 	private CreateNewElectricGuitarRequest createElectricGuitarRequest() throws Exception {
-		Constructor<CreateNewElectricGuitarRequest> createNewElectricGuitarRequestConstructor = CreateNewElectricGuitarRequest.class
-			.getDeclaredConstructor(String.class, List.class, InstrumentProgressStatus.class, AddressRequest.class,
-				Short.class, Integer.class, Boolean.class, String.class, ElectricGuitarBrand.class,
-				ElectricGuitarModel.class, Short.class, GuitarColor.class, List.class);
+		Constructor<CreateNewElectricGuitarRequest> createNewElectricGuitarRequestConstructor = CreateNewElectricGuitarRequest.class.getDeclaredConstructor(
+			String.class, List.class, InstrumentProgressStatus.class, AddressRequest.class,
+			Short.class, Integer.class, Boolean.class, String.class, ElectricGuitarBrand.class,
+			ElectricGuitarModel.class, Short.class, GuitarColor.class, List.class
+		);
 		createNewElectricGuitarRequestConstructor.setAccessible(true);
 		return createNewElectricGuitarRequestConstructor.newInstance(
 			"Test electric guitar",


### PR DESCRIPTION
## 🔥 Related Issue
- Close #52 

## 🏃‍ Task
- 전체 악기들에 대해 공통적인 필드를 재사용 가능하도록 DTO 분리
- Strategy pattern 사용하여 악기 매물 생성 로직 재사용 가능하도록 refactoring
- 베이스 기타 매물 생성 API 구현

## 📄 Reference
- None
