### PR TITLE
종류별 악기 목록 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,8 @@ jacocoTestReport {
                         excludes: [] + Qdomains,
                         includes: [
                                 '**/service/**',
-                                '**/controller/**'
+                                '**/controller/**',
+                                '**/repository/**'
                         ])
             }))
         }
@@ -145,7 +146,8 @@ jacocoTestCoverageVerification {
 
             includes = [
                     '*service.*Service*',
-                    '*controller.*Controller*'
+                    '*controller.*Controller*',
+                    '*repository.*Repository*'
             ]
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,12 @@ dependencies {
     // Spring Data JPA
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
     // Spring Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
@@ -87,6 +93,7 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+// Jacoco
 test {
     finalizedBy jacocoTestReport
 }
@@ -142,4 +149,15 @@ jacocoTestCoverageVerification {
             ]
         }
     }
+}
+
+// Querydsl
+def querydslGeneratedLocation = 'build/generated'
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslGeneratedLocation))
+}
+
+clean {
+    delete file(querydslGeneratedLocation)
 }

--- a/src/main/java/com/ajou/hertz/common/config/QuerydslConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.ajou.hertz.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.ajou.hertz.common.config;
 
 import static org.springframework.http.HttpMethod.*;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
@@ -39,18 +40,21 @@ public class SecurityConfig {
 		"/v3/api-docs/**"
 	};
 
-	private static final Map<String, HttpMethod> AUTH_WHITE_LIST = Map.of(
-		"/api/auth/login", POST,
-		"/api/auth/kakao/login", POST,
-		"/api/users", POST,
-		"/api/users/existence", GET,
-		"/api/users/email", GET,
-		"/api/administrative-areas/sido", GET,
-		"/api/administrative-areas/sgg", GET,
-		"/api/administrative-areas/emd", GET,
-		"/api/instruments", GET,
-		"/api/instruments/electric-guitars", GET
-	);
+	private static final Map<String, HttpMethod> AUTH_WHITE_LIST = new HashMap<>();
+
+	static {
+		AUTH_WHITE_LIST.put("/api/auth/login", POST);
+		AUTH_WHITE_LIST.put("/api/auth/kakao/login", POST);
+		AUTH_WHITE_LIST.put("/api/users", POST);
+		AUTH_WHITE_LIST.put("/api/users/existence", GET);
+		AUTH_WHITE_LIST.put("/api/users/email", GET);
+		AUTH_WHITE_LIST.put("/api/administrative-areas/sido", GET);
+		AUTH_WHITE_LIST.put("/api/administrative-areas/sgg", GET);
+		AUTH_WHITE_LIST.put("/api/administrative-areas/emd", GET);
+		AUTH_WHITE_LIST.put("/api/instruments", GET);
+		AUTH_WHITE_LIST.put("/api/instruments/electric-guitars", GET);
+		AUTH_WHITE_LIST.put("/api/instruments/bass-guitars", GET);
+	}
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
 		AUTH_WHITE_LIST.put("/api/instruments/acoustic-and-classic-guitars", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/effectors", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/amplifiers", GET);
+		AUTH_WHITE_LIST.put("/api/instruments/audio-equipments", GET);
 	}
 
 	@Bean

--- a/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
 		AUTH_WHITE_LIST.put("/api/instruments/bass-guitars", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/acoustic-and-classic-guitars", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/effectors", GET);
+		AUTH_WHITE_LIST.put("/api/instruments/amplifiers", GET);
 	}
 
 	@Bean

--- a/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
 		AUTH_WHITE_LIST.put("/api/instruments/electric-guitars", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/bass-guitars", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/acoustic-and-classic-guitars", GET);
+		AUTH_WHITE_LIST.put("/api/instruments/effectors", GET);
 	}
 
 	@Bean

--- a/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
 		"/api/administrative-areas/sido", GET,
 		"/api/administrative-areas/sgg", GET,
 		"/api/administrative-areas/emd", GET,
-		"/api/instruments", GET
+		"/api/instruments", GET,
+		"/api/instruments/electric-guitars", GET
 	);
 
 	@Bean

--- a/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
@@ -54,6 +54,7 @@ public class SecurityConfig {
 		AUTH_WHITE_LIST.put("/api/instruments", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/electric-guitars", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/bass-guitars", GET);
+		AUTH_WHITE_LIST.put("/api/instruments/acoustic-and-classic-guitars", GET);
 	}
 
 	@Bean

--- a/src/main/java/com/ajou/hertz/domain/instrument/constant/InstrumentSortOption.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/constant/InstrumentSortOption.java
@@ -6,10 +6,12 @@ import org.springframework.data.domain.Sort;
 
 public enum InstrumentSortOption {
 
+	CREATED_BY_ASC,
 	CREATED_BY_DESC;
 
 	public Sort toSort() {
 		return switch (this) {
+			case CREATED_BY_ASC -> Sort.by(ASC, "createdAt");
 			case CREATED_BY_DESC -> Sort.by(DESC, "createdAt");
 		};
 	}

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -126,6 +126,29 @@ public class InstrumentController {
 	}
 
 	@Operation(
+		summary = "어쿠스틱&클래식 기타 매물 목록 조회",
+		description = "어쿠스틱&클래식 기타 매물 목록을 조회합니다."
+	)
+	@GetMapping(value = "/acoustic-and-classic-guitars", headers = API_VERSION_HEADER_NAME + "=" + 1)
+	public Page<AcousticAndClassicGuitarResponse> findAcousticAndClassicGuitarsV1(
+		@Parameter(
+			description = "페이지 번호. 0부터 시작합니다.",
+			example = "0"
+		) @RequestParam int page,
+		@Parameter(
+			description = "페이지 크기. 한 페이지에 포함될 데이터의 개수를 의미합니다.",
+			example = "10"
+		) @RequestParam int size,
+		@Parameter(
+			description = "정렬 기준"
+		) @RequestParam InstrumentSortOption sort
+	) {
+		return instrumentQueryService
+			.findAcousticAndClassicGuitars(page, size, sort)
+			.map(AcousticAndClassicGuitarResponse::from);
+	}
+
+	@Operation(
 		summary = "일렉기타 매물 등록",
 		description = """
 			<p>일렉기타 매물을 등록합니다.

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -175,6 +175,29 @@ public class InstrumentController {
 		summary = "앰프 매물 목록 조회",
 		description = "앰프 매물 목록을 조회합니다."
 	)
+	@GetMapping(value = "/audio-equipments", headers = API_VERSION_HEADER_NAME + "=" + 1)
+	public Page<AudioEquipmentResponse> findAudioEquipmentsV1(
+		@Parameter(
+			description = "페이지 번호. 0부터 시작합니다.",
+			example = "0"
+		) @RequestParam int page,
+		@Parameter(
+			description = "페이지 크기. 한 페이지에 포함될 데이터의 개수를 의미합니다.",
+			example = "10"
+		) @RequestParam int size,
+		@Parameter(
+			description = "정렬 기준"
+		) @RequestParam InstrumentSortOption sort
+	) {
+		return instrumentQueryService
+			.findAudioEquipments(page, size, sort)
+			.map(AudioEquipmentResponse::from);
+	}
+
+	@Operation(
+		summary = "음향 장비 매물 목록 조회",
+		description = "음향 장비 매물 목록을 조회합니다."
+	)
 	@GetMapping(value = "/amplifiers", headers = API_VERSION_HEADER_NAME + "=" + 1)
 	public Page<AmplifierResponse> findAmplifiersV1(
 		@Parameter(

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -172,6 +172,29 @@ public class InstrumentController {
 	}
 
 	@Operation(
+		summary = "앰프 매물 목록 조회",
+		description = "앰프 매물 목록을 조회합니다."
+	)
+	@GetMapping(value = "/amplifiers", headers = API_VERSION_HEADER_NAME + "=" + 1)
+	public Page<AmplifierResponse> findAmplifiersV1(
+		@Parameter(
+			description = "페이지 번호. 0부터 시작합니다.",
+			example = "0"
+		) @RequestParam int page,
+		@Parameter(
+			description = "페이지 크기. 한 페이지에 포함될 데이터의 개수를 의미합니다.",
+			example = "10"
+		) @RequestParam int size,
+		@Parameter(
+			description = "정렬 기준"
+		) @RequestParam InstrumentSortOption sort
+	) {
+		return instrumentQueryService
+			.findAmplifiers(page, size, sort)
+			.map(AmplifierResponse::from);
+	}
+
+	@Operation(
 		summary = "일렉기타 매물 등록",
 		description = """
 			<p>일렉기타 매물을 등록합니다.

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -6,7 +6,6 @@ import java.net.URI;
 
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -75,9 +74,8 @@ public class InstrumentController {
 			description = "정렬 기준"
 		) @RequestParam InstrumentSortOption sort
 	) {
-		PageRequest pageRequest = PageRequest.of(page, size, sort.toSort());
 		return instrumentQueryService
-			.findInstruments(pageRequest)
+			.findInstruments(page, size, sort)
 			.map(InstrumentSummaryResponse::from);
 	}
 
@@ -100,8 +98,31 @@ public class InstrumentController {
 		) @RequestParam InstrumentSortOption sort
 	) {
 		return instrumentQueryService
-			.findElectricGuitars(PageRequest.of(page, size, sort.toSort()))
+			.findElectricGuitars(page, size, sort)
 			.map(ElectricGuitarResponse::from);
+	}
+
+	@Operation(
+		summary = "베이스 기타 매물 목록 조회",
+		description = "베이스 기타 매물 목록을 조회합니다."
+	)
+	@GetMapping(value = "/bass-guitars", headers = API_VERSION_HEADER_NAME + "=" + 1)
+	public Page<BassGuitarResponse> findBassGuitarsV1(
+		@Parameter(
+			description = "페이지 번호. 0부터 시작합니다.",
+			example = "0"
+		) @RequestParam int page,
+		@Parameter(
+			description = "페이지 크기. 한 페이지에 포함될 데이터의 개수를 의미합니다.",
+			example = "10"
+		) @RequestParam int size,
+		@Parameter(
+			description = "정렬 기준"
+		) @RequestParam InstrumentSortOption sort
+	) {
+		return instrumentQueryService
+			.findBassGuitars(page, size, sort)
+			.map(BassGuitarResponse::from);
 	}
 
 	@Operation(

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -30,6 +30,7 @@ import com.ajou.hertz.domain.instrument.dto.request.CreateNewAudioEquipmentReque
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewEffectorRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
+import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.response.AcousticAndClassicGuitarResponse;
 import com.ajou.hertz.domain.instrument.dto.response.AmplifierResponse;
 import com.ajou.hertz.domain.instrument.dto.response.AudioEquipmentResponse;
@@ -95,10 +96,11 @@ public class InstrumentController {
 		) @RequestParam int size,
 		@Parameter(
 			description = "정렬 기준"
-		) @RequestParam InstrumentSortOption sort
+		) @RequestParam InstrumentSortOption sort,
+		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findElectricGuitars(page, size, sort)
+			.findElectricGuitars(page, size, sort, filterConditions)
 			.map(ElectricGuitarResponse::from);
 	}
 
@@ -118,10 +120,11 @@ public class InstrumentController {
 		) @RequestParam int size,
 		@Parameter(
 			description = "정렬 기준"
-		) @RequestParam InstrumentSortOption sort
+		) @RequestParam InstrumentSortOption sort,
+		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findBassGuitars(page, size, sort)
+			.findBassGuitars(page, size, sort, filterConditions)
 			.map(BassGuitarResponse::from);
 	}
 
@@ -141,10 +144,11 @@ public class InstrumentController {
 		) @RequestParam int size,
 		@Parameter(
 			description = "정렬 기준"
-		) @RequestParam InstrumentSortOption sort
+		) @RequestParam InstrumentSortOption sort,
+		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findAcousticAndClassicGuitars(page, size, sort)
+			.findAcousticAndClassicGuitars(page, size, sort, filterConditions)
 			.map(AcousticAndClassicGuitarResponse::from);
 	}
 
@@ -164,39 +168,17 @@ public class InstrumentController {
 		) @RequestParam int size,
 		@Parameter(
 			description = "정렬 기준"
-		) @RequestParam InstrumentSortOption sort
+		) @RequestParam InstrumentSortOption sort,
+		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findEffectors(page, size, sort)
+			.findEffectors(page, size, sort, filterConditions)
 			.map(EffectorResponse::from);
 	}
 
 	@Operation(
 		summary = "앰프 매물 목록 조회",
 		description = "앰프 매물 목록을 조회합니다."
-	)
-	@GetMapping(value = "/audio-equipments", headers = API_VERSION_HEADER_NAME + "=" + 1)
-	public Page<AudioEquipmentResponse> findAudioEquipmentsV1(
-		@Parameter(
-			description = "페이지 번호. 0부터 시작합니다.",
-			example = "0"
-		) @RequestParam int page,
-		@Parameter(
-			description = "페이지 크기. 한 페이지에 포함될 데이터의 개수를 의미합니다.",
-			example = "10"
-		) @RequestParam int size,
-		@Parameter(
-			description = "정렬 기준"
-		) @RequestParam InstrumentSortOption sort
-	) {
-		return instrumentQueryService
-			.findAudioEquipments(page, size, sort)
-			.map(AudioEquipmentResponse::from);
-	}
-
-	@Operation(
-		summary = "음향 장비 매물 목록 조회",
-		description = "음향 장비 매물 목록을 조회합니다."
 	)
 	@GetMapping(value = "/amplifiers", headers = API_VERSION_HEADER_NAME + "=" + 1)
 	public Page<AmplifierResponse> findAmplifiersV1(
@@ -210,11 +192,36 @@ public class InstrumentController {
 		) @RequestParam int size,
 		@Parameter(
 			description = "정렬 기준"
-		) @RequestParam InstrumentSortOption sort
+		) @RequestParam InstrumentSortOption sort,
+		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findAmplifiers(page, size, sort)
+			.findAmplifiers(page, size, sort, filterConditions)
 			.map(AmplifierResponse::from);
+	}
+
+	@Operation(
+		summary = "음향 장비 매물 목록 조회",
+		description = "음향 장비 매물 목록을 조회합니다."
+	)
+	@GetMapping(value = "/audio-equipments", headers = API_VERSION_HEADER_NAME + "=" + 1)
+	public Page<AudioEquipmentResponse> findAudioEquipmentsV1(
+		@Parameter(
+			description = "페이지 번호. 0부터 시작합니다.",
+			example = "0"
+		) @RequestParam int page,
+		@Parameter(
+			description = "페이지 크기. 한 페이지에 포함될 데이터의 개수를 의미합니다.",
+			example = "10"
+		) @RequestParam int size,
+		@Parameter(
+			description = "정렬 기준"
+		) @RequestParam InstrumentSortOption sort,
+		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
+	) {
+		return instrumentQueryService
+			.findAudioEquipments(page, size, sort, filterConditions)
+			.map(AudioEquipmentResponse::from);
 	}
 
 	@Operation(

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -149,6 +149,29 @@ public class InstrumentController {
 	}
 
 	@Operation(
+		summary = "이펙터 매물 목록 조회",
+		description = "이펙터 매물 목록을 조회합니다."
+	)
+	@GetMapping(value = "/effectors", headers = API_VERSION_HEADER_NAME + "=" + 1)
+	public Page<EffectorResponse> findEffectorsV1(
+		@Parameter(
+			description = "페이지 번호. 0부터 시작합니다.",
+			example = "0"
+		) @RequestParam int page,
+		@Parameter(
+			description = "페이지 크기. 한 페이지에 포함될 데이터의 개수를 의미합니다.",
+			example = "10"
+		) @RequestParam int size,
+		@Parameter(
+			description = "정렬 기준"
+		) @RequestParam InstrumentSortOption sort
+	) {
+		return instrumentQueryService
+			.findEffectors(page, size, sort)
+			.map(EffectorResponse::from);
+	}
+
+	@Operation(
 		summary = "일렉기타 매물 등록",
 		description = """
 			<p>일렉기타 매물을 등록합니다.

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -62,7 +62,31 @@ public class InstrumentController {
 		description = "악기 종류와 상관 없이 전체 매물 목록을 조회합니다."
 	)
 	@GetMapping(headers = API_VERSION_HEADER_NAME + "=" + 1)
-	public Page<InstrumentSummaryResponse> findInstruments(
+	public Page<InstrumentSummaryResponse> findInstrumentsV1(
+		@Parameter(
+			description = "페이지 번호. 0부터 시작합니다.",
+			example = "0"
+		) @RequestParam int page,
+		@Parameter(
+			description = "페이지 크기. 한 페이지에 포함될 데이터의 개수를 의미합니다.",
+			example = "10"
+		) @RequestParam int size,
+		@Parameter(
+			description = "정렬 기준"
+		) @RequestParam InstrumentSortOption sort
+	) {
+		PageRequest pageRequest = PageRequest.of(page, size, sort.toSort());
+		return instrumentQueryService
+			.findInstruments(pageRequest)
+			.map(InstrumentSummaryResponse::from);
+	}
+
+	@Operation(
+		summary = "일렉 기타 매물 목록 조회",
+		description = "일렉 기타 매물 목록을 조회합니다."
+	)
+	@GetMapping(value = "/electric-guitars", headers = API_VERSION_HEADER_NAME + "=" + 1)
+	public Page<ElectricGuitarResponse> findElectricGuitarsV1(
 		@Parameter(
 			description = "페이지 번호. 0부터 시작합니다.",
 			example = "0"
@@ -76,8 +100,8 @@ public class InstrumentController {
 		) @RequestParam InstrumentSortOption sort
 	) {
 		return instrumentQueryService
-			.findInstruments(PageRequest.of(page, size, sort.toSort()))
-			.map(InstrumentSummaryResponse::from);
+			.findElectricGuitars(PageRequest.of(page, size, sort.toSort()))
+			.map(ElectricGuitarResponse::from);
 	}
 
 	@Operation(

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/InstrumentFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/InstrumentFilterConditions.java
@@ -1,0 +1,18 @@
+package com.ajou.hertz.domain.instrument.dto.request;
+
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter    // for @ModelAttribute
+@Getter
+public class InstrumentFilterConditions {
+
+	private InstrumentProgressStatus progress;
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepository.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 
-public interface InstrumentRepository extends JpaRepository<Instrument, Long> {
+public interface InstrumentRepository extends JpaRepository<Instrument, Long>, InstrumentRepositoryCustom {
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
+import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
@@ -22,4 +23,6 @@ public interface InstrumentRepositoryCustom {
 	Page<Effector> findEffectors(int page, int pageSize, InstrumentSortOption sort);
 
 	Page<Amplifier> findAmplifiers(int page, int pageSize, InstrumentSortOption sort);
+
+	Page<AudioEquipment> findAudioEquipments(int page, int pageSize, InstrumentSortOption sort);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.ajou.hertz.domain.instrument.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
+
+public interface InstrumentRepositoryCustom {
+
+	Page<ElectricGuitar> findElectricGuitars(Pageable pageable);
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
+import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
@@ -19,4 +20,6 @@ public interface InstrumentRepositoryCustom {
 	);
 
 	Page<Effector> findEffectors(int page, int pageSize, InstrumentSortOption sort);
+
+	Page<Amplifier> findAmplifiers(int page, int pageSize, InstrumentSortOption sort);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -1,11 +1,14 @@
 package com.ajou.hertz.domain.instrument.repository;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
+import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 
 public interface InstrumentRepositoryCustom {
 
-	Page<ElectricGuitar> findElectricGuitars(Pageable pageable);
+	Page<ElectricGuitar> findElectricGuitars(int page, int pageSize, InstrumentSortOption sort);
+
+	Page<BassGuitar> findBassGuitars(int page, int pageSize, InstrumentSortOption sort);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.ajou.hertz.domain.instrument.repository;
 import org.springframework.data.domain.Page;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
@@ -12,17 +13,27 @@ import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 
 public interface InstrumentRepositoryCustom {
 
-	Page<ElectricGuitar> findElectricGuitars(int page, int pageSize, InstrumentSortOption sort);
-
-	Page<BassGuitar> findBassGuitars(int page, int pageSize, InstrumentSortOption sort);
-
-	Page<AcousticAndClassicGuitar> findAcousticAndClassicGuitars(
-		int page, int pageSize, InstrumentSortOption sort
+	Page<ElectricGuitar> findElectricGuitars(
+		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
 	);
 
-	Page<Effector> findEffectors(int page, int pageSize, InstrumentSortOption sort);
+	Page<BassGuitar> findBassGuitars(
+		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+	);
 
-	Page<Amplifier> findAmplifiers(int page, int pageSize, InstrumentSortOption sort);
+	Page<AcousticAndClassicGuitar> findAcousticAndClassicGuitars(
+		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+	);
 
-	Page<AudioEquipment> findAudioEquipments(int page, int pageSize, InstrumentSortOption sort);
+	Page<Effector> findEffectors(
+		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+	);
+
+	Page<Amplifier> findAmplifiers(
+		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+	);
+
+	Page<AudioEquipment> findAudioEquipments(
+		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+	);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.ajou.hertz.domain.instrument.repository;
 import org.springframework.data.domain.Page;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 
@@ -11,4 +12,8 @@ public interface InstrumentRepositoryCustom {
 	Page<ElectricGuitar> findElectricGuitars(int page, int pageSize, InstrumentSortOption sort);
 
 	Page<BassGuitar> findBassGuitars(int page, int pageSize, InstrumentSortOption sort);
+
+	Page<AcousticAndClassicGuitar> findAcousticAndClassicGuitars(
+		int page, int pageSize, InstrumentSortOption sort
+	);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 
 public interface InstrumentRepositoryCustom {
@@ -16,4 +17,6 @@ public interface InstrumentRepositoryCustom {
 	Page<AcousticAndClassicGuitar> findAcousticAndClassicGuitars(
 		int page, int pageSize, InstrumentSortOption sort
 	);
+
+	Page<Effector> findEffectors(int page, int pageSize, InstrumentSortOption sort);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.ajou.hertz.domain.instrument.repository;
 import static com.ajou.hertz.domain.instrument.entity.QInstrument.*;
 import static com.ajou.hertz.domain.user.entity.QUser.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,7 +12,9 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
@@ -21,6 +24,8 @@ import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -33,49 +38,82 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Page<ElectricGuitar> findElectricGuitars(int page, int pageSize, InstrumentSortOption sort) {
-		return findInstrumentsByClassType(ElectricGuitar.class, page, pageSize, sort);
+	public Page<ElectricGuitar> findElectricGuitars(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
+		return findInstrumentsByClassType(ElectricGuitar.class, page, pageSize, sort, filterConditions);
 	}
 
 	@Override
-	public Page<BassGuitar> findBassGuitars(int page, int pageSize, InstrumentSortOption sort) {
-		return findInstrumentsByClassType(BassGuitar.class, page, pageSize, sort);
+	public Page<BassGuitar> findBassGuitars(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
+		return findInstrumentsByClassType(BassGuitar.class, page, pageSize, sort, filterConditions);
 	}
 
 	@Override
 	public Page<AcousticAndClassicGuitar> findAcousticAndClassicGuitars(
-		int page, int pageSize, InstrumentSortOption sort
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
 	) {
-		return findInstrumentsByClassType(AcousticAndClassicGuitar.class, page, pageSize, sort);
+		return findInstrumentsByClassType(AcousticAndClassicGuitar.class, page, pageSize, sort, filterConditions);
 	}
 
 	@Override
-	public Page<Effector> findEffectors(int page, int pageSize, InstrumentSortOption sort) {
-		return findInstrumentsByClassType(Effector.class, page, pageSize, sort);
+	public Page<Effector> findEffectors(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
+		return findInstrumentsByClassType(Effector.class, page, pageSize, sort, filterConditions);
 	}
 
 	@Override
-	public Page<Amplifier> findAmplifiers(int page, int pageSize, InstrumentSortOption sort) {
-		return findInstrumentsByClassType(Amplifier.class, page, pageSize, sort);
+	public Page<Amplifier> findAmplifiers(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
+		return findInstrumentsByClassType(Amplifier.class, page, pageSize, sort, filterConditions);
 	}
 
 	@Override
-	public Page<AudioEquipment> findAudioEquipments(int page, int pageSize, InstrumentSortOption sort) {
-		return findInstrumentsByClassType(AudioEquipment.class, page, pageSize, sort);
+	public Page<AudioEquipment> findAudioEquipments(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
+		return findInstrumentsByClassType(AudioEquipment.class, page, pageSize, sort, filterConditions);
 	}
 
 	private <T extends Instrument> Page<T> findInstrumentsByClassType(
 		Class<T> classType,
 		int page,
 		int pageSize,
-		InstrumentSortOption sort
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
 	) {
 		PageRequest pageable = PageRequest.of(page, pageSize, sort.toSort());
+
+		List<Predicate> conditions = new ArrayList<>();
+		conditions.add(instrument.instanceOf(classType));
+		conditions.addAll(convertFilterConditions(filterConditions));
 
 		List<T> content = queryFactory
 			.selectFrom(instrument)
 			.join(instrument.seller, user).fetchJoin()
-			.where(instrument.instanceOf(classType))
+			.where(conditions.toArray(Predicate[]::new))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.orderBy(convertSortToOrderSpecifiers(pageable.getSort()))
@@ -88,18 +126,28 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 			queryFactory.select(instrument.count())
 				.from(instrument)
 				.join(instrument.seller, user)
-				.where(instrument.instanceOf(classType))
+				.where(conditions.toArray(Predicate[]::new))
 				.fetchOne()
 		).orElse(0L);
 
 		return new PageImpl<>(content, pageable, totalCount);
 	}
 
-	public OrderSpecifier<?>[] convertSortToOrderSpecifiers(Sort sort) {
+	private OrderSpecifier<?>[] convertSortToOrderSpecifiers(Sort sort) {
 		return sort.stream()
 			.map(order -> new OrderSpecifier<>(
 				order.getDirection().isAscending() ? Order.ASC : Order.DESC,
 				INSTRUMENT_PATH.getString(order.getProperty())
 			)).toArray(OrderSpecifier[]::new);
+	}
+
+	private List<Predicate> convertFilterConditions(InstrumentFilterConditions filterConditions) {
+		List<Predicate> res = new ArrayList<>();
+		res.add(progressStatusFilterCondition(filterConditions.getProgress()));
+		return res;
+	}
+
+	private BooleanExpression progressStatusFilterCondition(InstrumentProgressStatus progressStatus) {
+		return progressStatus != null ? instrument.progressStatus.eq(progressStatus) : null;
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
@@ -1,0 +1,60 @@
+package com.ajou.hertz.domain.instrument.repository;
+
+import static com.ajou.hertz.domain.instrument.entity.QInstrument.*;
+import static com.ajou.hertz.domain.user.entity.QUser.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+	private static final PathBuilder<Instrument> INSTRUMENT_PATH = new PathBuilder<>(Instrument.class, "instrument");
+
+	public InstrumentRepositoryCustomImpl(JPAQueryFactory queryFactory) {
+		this.queryFactory = queryFactory;
+	}
+
+	@Override
+	public Page<ElectricGuitar> findElectricGuitars(Pageable pageable) {
+		List<ElectricGuitar> content = queryFactory.selectFrom(instrument)
+			.join(instrument.seller, user)
+			.fetchJoin()
+			.where(instrument.instanceOf(ElectricGuitar.class))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(convertSortToOrderSpecifiers(pageable.getSort()))
+			.fetch()
+			.stream()
+			.map(ElectricGuitar.class::cast)
+			.toList();
+
+		long totalCount = Optional.ofNullable(queryFactory.select(instrument.count())
+			.from(instrument)
+			.join(instrument.seller, user)
+			.where(instrument.instanceOf(ElectricGuitar.class))
+			.fetchOne()).orElse(0L);
+
+		return new PageImpl<>(content, pageable, totalCount);
+	}
+
+	public OrderSpecifier<?>[] convertSortToOrderSpecifiers(Sort sort) {
+		return sort.stream()
+			.map(order -> new OrderSpecifier<>(order.getDirection().isAscending() ? Order.ASC : Order.DESC,
+				INSTRUMENT_PATH.getString(order.getProperty())))
+			.toArray(OrderSpecifier[]::new);
+	}
+
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
@@ -36,6 +37,13 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 	@Override
 	public Page<BassGuitar> findBassGuitars(int page, int pageSize, InstrumentSortOption sort) {
 		return findInstrumentsByClassType(BassGuitar.class, page, pageSize, sort);
+	}
+
+	@Override
+	public Page<AcousticAndClassicGuitar> findAcousticAndClassicGuitars(
+		int page, int pageSize, InstrumentSortOption sort
+	) {
+		return findInstrumentsByClassType(AcousticAndClassicGuitar.class, page, pageSize, sort);
 	}
 
 	private <T extends Instrument> Page<T> findInstrumentsByClassType(

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Sort;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.querydsl.core.types.Order;
@@ -44,6 +45,11 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 		int page, int pageSize, InstrumentSortOption sort
 	) {
 		return findInstrumentsByClassType(AcousticAndClassicGuitar.class, page, pageSize, sort);
+	}
+
+	@Override
+	public Page<Effector> findEffectors(int page, int pageSize, InstrumentSortOption sort) {
+		return findInstrumentsByClassType(Effector.class, page, pageSize, sort);
 	}
 
 	private <T extends Instrument> Page<T> findInstrumentsByClassType(

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Sort;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
+import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
@@ -50,6 +51,11 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 	@Override
 	public Page<Effector> findEffectors(int page, int pageSize, InstrumentSortOption sort) {
 		return findInstrumentsByClassType(Effector.class, page, pageSize, sort);
+	}
+
+	@Override
+	public Page<Amplifier> findAmplifiers(int page, int pageSize, InstrumentSortOption sort) {
+		return findInstrumentsByClassType(Amplifier.class, page, pageSize, sort);
 	}
 
 	private <T extends Instrument> Page<T> findInstrumentsByClassType(

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Sort;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
+import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
@@ -56,6 +57,11 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 	@Override
 	public Page<Amplifier> findAmplifiers(int page, int pageSize, InstrumentSortOption sort) {
 		return findInstrumentsByClassType(Amplifier.class, page, pageSize, sort);
+	}
+
+	@Override
+	public Page<AudioEquipment> findAudioEquipments(int page, int pageSize, InstrumentSortOption sort) {
+		return findInstrumentsByClassType(AudioEquipment.class, page, pageSize, sort);
 	}
 
 	private <T extends Instrument> Page<T> findInstrumentsByClassType(

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
@@ -8,9 +8,11 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
+import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.querydsl.core.types.Order;
@@ -18,43 +20,60 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCustom {
 
-	private final JPAQueryFactory queryFactory;
 	private static final PathBuilder<Instrument> INSTRUMENT_PATH = new PathBuilder<>(Instrument.class, "instrument");
+	private final JPAQueryFactory queryFactory;
 
-	public InstrumentRepositoryCustomImpl(JPAQueryFactory queryFactory) {
-		this.queryFactory = queryFactory;
+	@Override
+	public Page<ElectricGuitar> findElectricGuitars(int page, int pageSize, InstrumentSortOption sort) {
+		return findInstrumentsByClassType(ElectricGuitar.class, page, pageSize, sort);
 	}
 
 	@Override
-	public Page<ElectricGuitar> findElectricGuitars(Pageable pageable) {
-		List<ElectricGuitar> content = queryFactory.selectFrom(instrument)
-			.join(instrument.seller, user)
-			.fetchJoin()
-			.where(instrument.instanceOf(ElectricGuitar.class))
+	public Page<BassGuitar> findBassGuitars(int page, int pageSize, InstrumentSortOption sort) {
+		return findInstrumentsByClassType(BassGuitar.class, page, pageSize, sort);
+	}
+
+	private <T extends Instrument> Page<T> findInstrumentsByClassType(
+		Class<T> classType,
+		int page,
+		int pageSize,
+		InstrumentSortOption sort
+	) {
+		PageRequest pageable = PageRequest.of(page, pageSize, sort.toSort());
+
+		List<T> content = queryFactory
+			.selectFrom(instrument)
+			.join(instrument.seller, user).fetchJoin()
+			.where(instrument.instanceOf(classType))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
 			.orderBy(convertSortToOrderSpecifiers(pageable.getSort()))
 			.fetch()
 			.stream()
-			.map(ElectricGuitar.class::cast)
+			.map(classType::cast)
 			.toList();
 
-		long totalCount = Optional.ofNullable(queryFactory.select(instrument.count())
-			.from(instrument)
-			.join(instrument.seller, user)
-			.where(instrument.instanceOf(ElectricGuitar.class))
-			.fetchOne()).orElse(0L);
+		long totalCount = Optional.ofNullable(
+			queryFactory.select(instrument.count())
+				.from(instrument)
+				.join(instrument.seller, user)
+				.where(instrument.instanceOf(classType))
+				.fetchOne()
+		).orElse(0L);
 
 		return new PageImpl<>(content, pageable, totalCount);
 	}
 
 	public OrderSpecifier<?>[] convertSortToOrderSpecifiers(Sort sort) {
 		return sort.stream()
-			.map(order -> new OrderSpecifier<>(order.getDirection().isAscending() ? Order.ASC : Order.DESC,
-				INSTRUMENT_PATH.getString(order.getProperty())))
-			.toArray(OrderSpecifier[]::new);
+			.map(order -> new OrderSpecifier<>(
+				order.getDirection().isAscending() ? Order.ASC : Order.DESC,
+				INSTRUMENT_PATH.getString(order.getProperty())
+			)).toArray(OrderSpecifier[]::new);
 	}
-
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -1,10 +1,12 @@
 package com.ajou.hertz.domain.instrument.service;
 
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
@@ -18,15 +20,21 @@ public class InstrumentQueryService {
 
 	private final InstrumentRepository instrumentRepository;
 
-	public Page<InstrumentDto> findInstruments(Pageable pageable) {
+	public Page<InstrumentDto> findInstruments(int page, int pageSize, InstrumentSortOption sort) {
 		return instrumentRepository
-			.findAll(pageable)
+			.findAll(PageRequest.of(page, pageSize, sort.toSort()))
 			.map(InstrumentDto::from);
 	}
 
-	public Page<ElectricGuitarDto> findElectricGuitars(Pageable pageable) {
+	public Page<ElectricGuitarDto> findElectricGuitars(int page, int pageSize, InstrumentSortOption sort) {
 		return instrumentRepository
-			.findElectricGuitars(pageable)
+			.findElectricGuitars(page, pageSize, sort)
 			.map(ElectricGuitarDto::from);
+	}
+
+	public Page<BassGuitarDto> findBassGuitars(int page, int pageSize, InstrumentSortOption sort) {
+		return instrumentRepository
+			.findBassGuitars(page, pageSize, sort)
+			.map(BassGuitarDto::from);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.AmplifierDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
@@ -52,5 +53,11 @@ public class InstrumentQueryService {
 		return instrumentRepository
 			.findEffectors(page, pageSize, sort)
 			.map(EffectorDto::from);
+	}
+
+	public Page<AmplifierDto> findAmplifiers(int page, int pageSize, InstrumentSortOption sort) {
+		return instrumentRepository
+			.findAmplifiers(page, pageSize, sort)
+			.map(AmplifierDto::from);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.AmplifierDto;
+import com.ajou.hertz.domain.instrument.dto.AudioEquipmentDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
@@ -59,5 +60,11 @@ public class InstrumentQueryService {
 		return instrumentRepository
 			.findAmplifiers(page, pageSize, sort)
 			.map(AmplifierDto::from);
+	}
+
+	public Page<AudioEquipmentDto> findAudioEquipments(int page, int pageSize, InstrumentSortOption sort) {
+		return instrumentRepository
+			.findAudioEquipments(page, pageSize, sort)
+			.map(AudioEquipmentDto::from);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
 
@@ -21,5 +22,11 @@ public class InstrumentQueryService {
 		return instrumentRepository
 			.findAll(pageable)
 			.map(InstrumentDto::from);
+	}
+
+	public Page<ElectricGuitarDto> findElectricGuitars(Pageable pageable) {
+		return instrumentRepository
+			.findElectricGuitars(pageable)
+			.map(ElectricGuitarDto::from);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
@@ -45,5 +46,11 @@ public class InstrumentQueryService {
 		return instrumentRepository
 			.findAcousticAndClassicGuitars(page, pageSize, sort)
 			.map(AcousticAndClassicGuitarDto::from);
+	}
+
+	public Page<EffectorDto> findEffectors(int page, int pageSize, InstrumentSortOption sort) {
+		return instrumentRepository
+			.findEffectors(page, pageSize, sort)
+			.map(EffectorDto::from);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
@@ -36,5 +37,13 @@ public class InstrumentQueryService {
 		return instrumentRepository
 			.findBassGuitars(page, pageSize, sort)
 			.map(BassGuitarDto::from);
+	}
+
+	public Page<AcousticAndClassicGuitarDto> findAcousticAndClassicGuitars(
+		int page, int pageSize, InstrumentSortOption sort
+	) {
+		return instrumentRepository
+			.findAcousticAndClassicGuitars(page, pageSize, sort)
+			.map(AcousticAndClassicGuitarDto::from);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -13,6 +13,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -30,41 +31,69 @@ public class InstrumentQueryService {
 			.map(InstrumentDto::from);
 	}
 
-	public Page<ElectricGuitarDto> findElectricGuitars(int page, int pageSize, InstrumentSortOption sort) {
+	public Page<ElectricGuitarDto> findElectricGuitars(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
 		return instrumentRepository
-			.findElectricGuitars(page, pageSize, sort)
+			.findElectricGuitars(page, pageSize, sort, filterConditions)
 			.map(ElectricGuitarDto::from);
 	}
 
-	public Page<BassGuitarDto> findBassGuitars(int page, int pageSize, InstrumentSortOption sort) {
+	public Page<BassGuitarDto> findBassGuitars(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
 		return instrumentRepository
-			.findBassGuitars(page, pageSize, sort)
+			.findBassGuitars(page, pageSize, sort, filterConditions)
 			.map(BassGuitarDto::from);
 	}
 
 	public Page<AcousticAndClassicGuitarDto> findAcousticAndClassicGuitars(
-		int page, int pageSize, InstrumentSortOption sort
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
 	) {
 		return instrumentRepository
-			.findAcousticAndClassicGuitars(page, pageSize, sort)
+			.findAcousticAndClassicGuitars(page, pageSize, sort, filterConditions)
 			.map(AcousticAndClassicGuitarDto::from);
 	}
 
-	public Page<EffectorDto> findEffectors(int page, int pageSize, InstrumentSortOption sort) {
+	public Page<EffectorDto> findEffectors(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
 		return instrumentRepository
-			.findEffectors(page, pageSize, sort)
+			.findEffectors(page, pageSize, sort, filterConditions)
 			.map(EffectorDto::from);
 	}
 
-	public Page<AmplifierDto> findAmplifiers(int page, int pageSize, InstrumentSortOption sort) {
+	public Page<AmplifierDto> findAmplifiers(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
 		return instrumentRepository
-			.findAmplifiers(page, pageSize, sort)
+			.findAmplifiers(page, pageSize, sort, filterConditions)
 			.map(AmplifierDto::from);
 	}
 
-	public Page<AudioEquipmentDto> findAudioEquipments(int page, int pageSize, InstrumentSortOption sort) {
+	public Page<AudioEquipmentDto> findAudioEquipments(
+		int page,
+		int pageSize,
+		InstrumentSortOption sort,
+		InstrumentFilterConditions filterConditions
+	) {
 		return instrumentRepository
-			.findAudioEquipments(page, pageSize, sort)
+			.findAudioEquipments(page, pageSize, sort, filterConditions)
 			.map(AudioEquipmentDto::from);
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
@@ -18,6 +18,10 @@ import org.springframework.test.context.ActiveProfiles;
 import com.ajou.hertz.common.config.JpaConfig;
 import com.ajou.hertz.common.config.QuerydslConfig;
 import com.ajou.hertz.common.entity.Address;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarModel;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
@@ -26,6 +30,7 @@ import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
@@ -82,6 +87,25 @@ class InstrumentRepositoryCustomImplTest {
 
 		// when
 		Page<BassGuitar> result = sut.findBassGuitars(0, 10, InstrumentSortOption.CREATED_BY_ASC);
+
+		// then
+		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
+	}
+
+	@Test
+	void 어쿠스틱_클래식_기타_목록을_조회한다() throws Exception {
+		// given
+		User user = userRepository.save(createUser());
+		List<Instrument> savedInstruments = sut.saveAll(List.of(
+			createElectricGuitar(user),
+			createAcousticAndClassicGuitar(user),
+			createAcousticAndClassicGuitar(user)
+		));
+
+		// when
+		Page<AcousticAndClassicGuitar> result = sut.findAcousticAndClassicGuitars(
+			0, 10, InstrumentSortOption.CREATED_BY_ASC
+		);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -156,6 +180,32 @@ class InstrumentRepositoryCustomImplTest {
 			BassGuitarPickUp.JAZZ,
 			BassGuitarPreAmplifier.ACTIVE,
 			GuitarColor.RED
+		);
+	}
+
+	private AcousticAndClassicGuitar createAcousticAndClassicGuitar(User seller) throws Exception {
+		Constructor<AcousticAndClassicGuitar> acousticAndClassicGuitarConstructor =
+			AcousticAndClassicGuitar.class.getDeclaredConstructor(
+				Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+				Short.class, Integer.class, Boolean.class, String.class,
+				AcousticAndClassicGuitarBrand.class, AcousticAndClassicGuitarModel.class,
+				AcousticAndClassicGuitarWood.class, AcousticAndClassicGuitarPickUp.class
+			);
+		acousticAndClassicGuitarConstructor.setAccessible(true);
+		return acousticAndClassicGuitarConstructor.newInstance(
+			null,
+			seller,
+			"Test electric guitar",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			AcousticAndClassicGuitarBrand.HEX,
+			AcousticAndClassicGuitarModel.JUMBO_BODY,
+			AcousticAndClassicGuitarWood.PLYWOOD,
+			AcousticAndClassicGuitarPickUp.MICROPHONE
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
@@ -1,0 +1,161 @@
+package com.ajou.hertz.integration.domain.instrument.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Constructor;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.ajou.hertz.common.config.JpaConfig;
+import com.ajou.hertz.common.config.QuerydslConfig;
+import com.ajou.hertz.common.entity.Address;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.ElectricGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
+import com.ajou.hertz.domain.instrument.constant.GuitarColor;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
+import com.ajou.hertz.domain.user.constant.Gender;
+import com.ajou.hertz.domain.user.constant.RoleType;
+import com.ajou.hertz.domain.user.entity.User;
+import com.ajou.hertz.domain.user.repository.UserRepository;
+
+@DisplayName("[Integration] Repository - Instrument")
+@ActiveProfiles("test")
+@Import({QuerydslConfig.class, JpaConfig.class})
+@DataJpaTest
+class InstrumentRepositoryCustomImplTest {
+
+	private final InstrumentRepository sut;
+	private final UserRepository userRepository;
+
+	@Autowired
+	public InstrumentRepositoryCustomImplTest(
+		InstrumentRepository instrumentRepository,
+		UserRepository userRepository
+	) {
+		this.sut = instrumentRepository;
+		this.userRepository = userRepository;
+	}
+
+	@Test
+	void 일렉_기타_목록을_조회한다() throws Exception {
+		// given
+		User user = userRepository.save(createUser());
+		List<Instrument> savedInstruments = sut.saveAll(List.of(
+			createBassGuitar(user),
+			createElectricGuitar(user),
+			createElectricGuitar(user)
+		));
+
+		// when
+		Page<ElectricGuitar> result = sut.findElectricGuitars(0, 10, InstrumentSortOption.CREATED_BY_DESC);
+
+		// then
+		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
+	}
+
+	@Test
+	void 베이스_기타_목록을_조회한다() throws Exception {
+		// given
+		User user = userRepository.save(createUser());
+		List<Instrument> savedInstruments = sut.saveAll(List.of(
+			createElectricGuitar(user),
+			createBassGuitar(user),
+			createBassGuitar(user)
+		));
+
+		// when
+		Page<BassGuitar> result = sut.findBassGuitars(0, 10, InstrumentSortOption.CREATED_BY_ASC);
+
+		// then
+		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
+	}
+
+	private Address createAddress() {
+		return new Address("서울특별시", "강남구", "청담동");
+	}
+
+	private User createUser() throws Exception {
+		Constructor<User> userConstructor = User.class.getDeclaredConstructor(
+			Long.class, Set.class, String.class, String.class, String.class,
+			String.class, LocalDate.class, Gender.class, String.class, String.class
+		);
+		userConstructor.setAccessible(true);
+		return userConstructor.newInstance(
+			null,
+			Set.of(RoleType.USER),
+			"test@mail.com",
+			"password",
+			"12345",
+			"https://user-default-profile-image-url",
+			LocalDate.of(2024, 1, 1),
+			Gender.ETC,
+			"01012345678",
+			null
+		);
+	}
+
+	private ElectricGuitar createElectricGuitar(User seller) throws Exception {
+		Constructor<ElectricGuitar> electricGuitarConstructor = ElectricGuitar.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class, Short.class,
+			Integer.class, Boolean.class, String.class, ElectricGuitarBrand.class, ElectricGuitarModel.class,
+			Short.class, GuitarColor.class
+		);
+		electricGuitarConstructor.setAccessible(true);
+		return electricGuitarConstructor.newInstance(
+			null,
+			seller,
+			"Test electric guitar",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			ElectricGuitarBrand.FENDER_USA,
+			ElectricGuitarModel.TELECASTER,
+			(short)2014,
+			GuitarColor.RED
+		);
+	}
+
+	private BassGuitar createBassGuitar(User seller) throws Exception {
+		Constructor<BassGuitar> bassGuitarConstructor = BassGuitar.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+			Short.class, Integer.class, Boolean.class, String.class,
+			BassGuitarBrand.class, BassGuitarPickUp.class, BassGuitarPreAmplifier.class, GuitarColor.class
+		);
+		bassGuitarConstructor.setAccessible(true);
+		return bassGuitarConstructor.newInstance(
+			null,
+			seller,
+			"Test electric guitar",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			BassGuitarBrand.FENDER,
+			BassGuitarPickUp.JAZZ,
+			BassGuitarPreAmplifier.ACTIVE,
+			GuitarColor.RED
+		);
+	}
+}

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
@@ -25,6 +25,8 @@ import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.EffectorFeature;
+import com.ajou.hertz.domain.instrument.constant.EffectorType;
 import com.ajou.hertz.domain.instrument.constant.ElectricGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
@@ -32,6 +34,7 @@ import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
@@ -106,6 +109,23 @@ class InstrumentRepositoryCustomImplTest {
 		Page<AcousticAndClassicGuitar> result = sut.findAcousticAndClassicGuitars(
 			0, 10, InstrumentSortOption.CREATED_BY_ASC
 		);
+
+		// then
+		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
+	}
+
+	@Test
+	void 이펙터_목록을_조회한다() throws Exception {
+		// given
+		User user = userRepository.save(createUser());
+		List<Instrument> savedInstruments = sut.saveAll(List.of(
+			createElectricGuitar(user),
+			createEffector(user),
+			createEffector(user)
+		));
+
+		// when
+		Page<Effector> result = sut.findEffectors(0, 10, InstrumentSortOption.CREATED_BY_ASC);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -206,6 +226,28 @@ class InstrumentRepositoryCustomImplTest {
 			AcousticAndClassicGuitarModel.JUMBO_BODY,
 			AcousticAndClassicGuitarWood.PLYWOOD,
 			AcousticAndClassicGuitarPickUp.MICROPHONE
+		);
+	}
+
+	private Effector createEffector(User seller) throws Exception {
+		Constructor<Effector> effectorConstructor = Effector.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+			Short.class, Integer.class, Boolean.class, String.class,
+			EffectorType.class, EffectorFeature.class
+		);
+		effectorConstructor.setAccessible(true);
+		return effectorConstructor.newInstance(
+			null,
+			seller,
+			"Title",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			EffectorType.GUITAR,
+			EffectorFeature.ETC
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
@@ -25,6 +25,7 @@ import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
 import com.ajou.hertz.domain.instrument.constant.AmplifierBrand;
 import com.ajou.hertz.domain.instrument.constant.AmplifierType;
 import com.ajou.hertz.domain.instrument.constant.AmplifierUsage;
+import com.ajou.hertz.domain.instrument.constant.AudioEquipmentType;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
@@ -37,6 +38,7 @@ import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
+import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
@@ -147,6 +149,23 @@ class InstrumentRepositoryCustomImplTest {
 
 		// when
 		Page<Amplifier> result = sut.findAmplifiers(0, 10, InstrumentSortOption.CREATED_BY_ASC);
+
+		// then
+		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
+	}
+
+	@Test
+	void 음향_장비_목록을_조회한다() throws Exception {
+		// given
+		User user = userRepository.save(createUser());
+		List<Instrument> savedInstruments = sut.saveAll(List.of(
+			createElectricGuitar(user),
+			createAudioEquipment(user),
+			createAudioEquipment(user)
+		));
+
+		// when
+		Page<AudioEquipment> result = sut.findAudioEquipments(0, 10, InstrumentSortOption.CREATED_BY_ASC);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -292,6 +311,27 @@ class InstrumentRepositoryCustomImplTest {
 			AmplifierType.GUITAR,
 			AmplifierBrand.FENDER,
 			AmplifierUsage.HOME
+		);
+	}
+
+	private AudioEquipment createAudioEquipment(User seller) throws Exception {
+		Constructor<AudioEquipment> audioEquipmentConstructor = AudioEquipment.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+			Short.class, Integer.class, Boolean.class, String.class,
+			AudioEquipmentType.class
+		);
+		audioEquipmentConstructor.setAccessible(true);
+		return audioEquipmentConstructor.newInstance(
+			null,
+			seller,
+			"Title",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			AudioEquipmentType.AUDIO_EQUIPMENT
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryCustomImplTest.java
@@ -22,6 +22,9 @@ import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
+import com.ajou.hertz.domain.instrument.constant.AmplifierBrand;
+import com.ajou.hertz.domain.instrument.constant.AmplifierType;
+import com.ajou.hertz.domain.instrument.constant.AmplifierUsage;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
@@ -33,6 +36,7 @@ import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
+import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
@@ -126,6 +130,23 @@ class InstrumentRepositoryCustomImplTest {
 
 		// when
 		Page<Effector> result = sut.findEffectors(0, 10, InstrumentSortOption.CREATED_BY_ASC);
+
+		// then
+		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
+	}
+
+	@Test
+	void 앰프_목록을_조회한다() throws Exception {
+		// given
+		User user = userRepository.save(createUser());
+		List<Instrument> savedInstruments = sut.saveAll(List.of(
+			createElectricGuitar(user),
+			createAmplifier(user),
+			createAmplifier(user)
+		));
+
+		// when
+		Page<Amplifier> result = sut.findAmplifiers(0, 10, InstrumentSortOption.CREATED_BY_ASC);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -248,6 +269,29 @@ class InstrumentRepositoryCustomImplTest {
 			"description",
 			EffectorType.GUITAR,
 			EffectorFeature.ETC
+		);
+	}
+
+	private Amplifier createAmplifier(User seller) throws Exception {
+		Constructor<Amplifier> amplifierConstructor = Amplifier.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+			Short.class, Integer.class, Boolean.class, String.class,
+			AmplifierType.class, AmplifierBrand.class, AmplifierUsage.class
+		);
+		amplifierConstructor.setAccessible(true);
+		return amplifierConstructor.newInstance(
+			null,
+			seller,
+			"Title",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			AmplifierType.GUITAR,
+			AmplifierBrand.FENDER,
+			AmplifierUsage.HOME
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
@@ -36,6 +36,7 @@ import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
@@ -53,13 +54,13 @@ import com.ajou.hertz.domain.user.repository.UserRepository;
 @ActiveProfiles("test")
 @Import({QuerydslConfig.class, JpaConfig.class})
 @DataJpaTest
-class InstrumentRepositoryCustomImplTest {
+class InstrumentRepositoryTest {
 
 	private final InstrumentRepository sut;
 	private final UserRepository userRepository;
 
 	@Autowired
-	public InstrumentRepositoryCustomImplTest(
+	public InstrumentRepositoryTest(
 		InstrumentRepository instrumentRepository,
 		UserRepository userRepository
 	) {
@@ -70,6 +71,9 @@ class InstrumentRepositoryCustomImplTest {
 	@Test
 	void 일렉_기타_목록을_조회한다() throws Exception {
 		// given
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		InstrumentFilterConditions filterConditions =
+			createInstrumentFilterConditions(InstrumentProgressStatus.SELLING);
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createBassGuitar(user),
@@ -78,7 +82,7 @@ class InstrumentRepositoryCustomImplTest {
 		));
 
 		// when
-		Page<ElectricGuitar> result = sut.findElectricGuitars(0, 10, InstrumentSortOption.CREATED_BY_DESC);
+		Page<ElectricGuitar> result = sut.findElectricGuitars(0, 10, sortOption, filterConditions);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -87,6 +91,8 @@ class InstrumentRepositoryCustomImplTest {
 	@Test
 	void 베이스_기타_목록을_조회한다() throws Exception {
 		// given
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -95,7 +101,7 @@ class InstrumentRepositoryCustomImplTest {
 		));
 
 		// when
-		Page<BassGuitar> result = sut.findBassGuitars(0, 10, InstrumentSortOption.CREATED_BY_ASC);
+		Page<BassGuitar> result = sut.findBassGuitars(0, 10, sortOption, filterConditions);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -104,6 +110,8 @@ class InstrumentRepositoryCustomImplTest {
 	@Test
 	void 어쿠스틱_클래식_기타_목록을_조회한다() throws Exception {
 		// given
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -113,7 +121,7 @@ class InstrumentRepositoryCustomImplTest {
 
 		// when
 		Page<AcousticAndClassicGuitar> result = sut.findAcousticAndClassicGuitars(
-			0, 10, InstrumentSortOption.CREATED_BY_ASC
+			0, 10, sortOption, filterConditions
 		);
 
 		// then
@@ -123,6 +131,8 @@ class InstrumentRepositoryCustomImplTest {
 	@Test
 	void 이펙터_목록을_조회한다() throws Exception {
 		// given
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -131,7 +141,7 @@ class InstrumentRepositoryCustomImplTest {
 		));
 
 		// when
-		Page<Effector> result = sut.findEffectors(0, 10, InstrumentSortOption.CREATED_BY_ASC);
+		Page<Effector> result = sut.findEffectors(0, 10, sortOption, filterConditions);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -140,6 +150,8 @@ class InstrumentRepositoryCustomImplTest {
 	@Test
 	void 앰프_목록을_조회한다() throws Exception {
 		// given
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -148,7 +160,7 @@ class InstrumentRepositoryCustomImplTest {
 		));
 
 		// when
-		Page<Amplifier> result = sut.findAmplifiers(0, 10, InstrumentSortOption.CREATED_BY_ASC);
+		Page<Amplifier> result = sut.findAmplifiers(0, 10, sortOption, filterConditions);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -157,6 +169,8 @@ class InstrumentRepositoryCustomImplTest {
 	@Test
 	void 음향_장비_목록을_조회한다() throws Exception {
 		// given
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_ASC;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -165,7 +179,7 @@ class InstrumentRepositoryCustomImplTest {
 		));
 
 		// when
-		Page<AudioEquipment> result = sut.findAudioEquipments(0, 10, InstrumentSortOption.CREATED_BY_ASC);
+		Page<AudioEquipment> result = sut.findAudioEquipments(0, 10, sortOption, filterConditions);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -333,5 +347,20 @@ class InstrumentRepositoryCustomImplTest {
 			"description",
 			AudioEquipmentType.AUDIO_EQUIPMENT
 		);
+	}
+
+	private InstrumentFilterConditions createInstrumentFilterConditions() throws Exception {
+		Constructor<InstrumentFilterConditions> instrumentFilterConditionsConstructor =
+			InstrumentFilterConditions.class.getDeclaredConstructor();
+		instrumentFilterConditionsConstructor.setAccessible(true);
+		return instrumentFilterConditionsConstructor.newInstance();
+	}
+
+	private InstrumentFilterConditions createInstrumentFilterConditions(InstrumentProgressStatus progressStatus) throws
+		Exception {
+		Constructor<InstrumentFilterConditions> instrumentFilterConditionsConstructor =
+			InstrumentFilterConditions.class.getDeclaredConstructor(InstrumentProgressStatus.class);
+		instrumentFilterConditionsConstructor.setAccessible(true);
+		return instrumentFilterConditionsConstructor.newInstance(progressStatus);
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -209,6 +209,36 @@ class InstrumentControllerTest {
 	}
 
 	@Test
+	void 이펙터_매물_목록을_조회한다() throws Exception {
+		// given
+		long userId = 1L;
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		Page<EffectorDto> expectedResult = new PageImpl<>(List.of(
+			createEffectorDto(2L, userId),
+			createEffectorDto(3L, userId),
+			createEffectorDto(4L, userId)
+		));
+		given(instrumentQueryService.findEffectors(page, pageSize, sortOption)).willReturn(expectedResult);
+
+		// when & then
+		mvc.perform(
+				get("/api/instruments/effectors")
+					.header(API_VERSION_HEADER_NAME, 1)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(pageSize))
+					.param("sort", sortOption.name())
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
+			.andExpect(jsonPath("$.content").isArray())
+			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
+		then(instrumentQueryService).should().findEffectors(page, pageSize, sortOption);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
+	@Test
 	void 새로_등록할_일렉기타의_정보가_주어지면_일렉기타_매물을_등록한다() throws Exception {
 		// given
 		long sellerId = 1L;

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -178,6 +178,37 @@ class InstrumentControllerTest {
 	}
 
 	@Test
+	void 어쿠스틱_클래식_기타_매물_목록을_조회한다() throws Exception {
+		// given
+		long userId = 1L;
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		Page<AcousticAndClassicGuitarDto> expectedResult = new PageImpl<>(List.of(
+			createAcousticAndClassicGuitarDto(2L, userId),
+			createAcousticAndClassicGuitarDto(3L, userId),
+			createAcousticAndClassicGuitarDto(4L, userId)
+		));
+		given(instrumentQueryService.findAcousticAndClassicGuitars(page, pageSize, sortOption))
+			.willReturn(expectedResult);
+
+		// when & then
+		mvc.perform(
+				get("/api/instruments/acoustic-and-classic-guitars")
+					.header(API_VERSION_HEADER_NAME, 1)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(pageSize))
+					.param("sort", sortOption.name())
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
+			.andExpect(jsonPath("$.content").isArray())
+			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
+		then(instrumentQueryService).should().findAcousticAndClassicGuitars(page, pageSize, sortOption);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
+	@Test
 	void 새로_등록할_일렉기타의_정보가_주어지면_일렉기타_매물을_등록한다() throws Exception {
 		// given
 		long sellerId = 1L;

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -119,6 +119,36 @@ class InstrumentControllerTest {
 	}
 
 	@Test
+	void 일렉_기타_매물_목록을_조회한다() throws Exception {
+		// given
+		long userId = 1L;
+		int pageNumber = 0;
+		int pageSize = 10;
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		Page<ElectricGuitarDto> expectedResult = new PageImpl<>(List.of(
+			createElectricGuitarDto(2L, userId),
+			createElectricGuitarDto(3L, userId),
+			createElectricGuitarDto(4L, userId)
+		));
+		given(instrumentQueryService.findElectricGuitars(any(Pageable.class))).willReturn(expectedResult);
+
+		// when & then
+		mvc.perform(
+				get("/api/instruments/electric-guitars")
+					.header(API_VERSION_HEADER_NAME, 1)
+					.param("page", String.valueOf(pageNumber))
+					.param("size", String.valueOf(pageSize))
+					.param("sort", sortOption.name())
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
+			.andExpect(jsonPath("$.content").isArray())
+			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
+		then(instrumentQueryService).should().findElectricGuitars(any(Pageable.class));
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
+	@Test
 	void 새로_등록할_일렉기타의_정보가_주어지면_일렉기타_매물을_등록한다() throws Exception {
 		// given
 		long sellerId = 1L;

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -269,6 +269,36 @@ class InstrumentControllerTest {
 	}
 
 	@Test
+	void 음향_장비_매물_목록을_조회한다() throws Exception {
+		// given
+		long userId = 1L;
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		Page<AudioEquipmentDto> expectedResult = new PageImpl<>(List.of(
+			createAudioEquipmentDto(2L, userId),
+			createAudioEquipmentDto(3L, userId),
+			createAudioEquipmentDto(4L, userId)
+		));
+		given(instrumentQueryService.findAudioEquipments(page, pageSize, sortOption)).willReturn(expectedResult);
+
+		// when & then
+		mvc.perform(
+				get("/api/instruments/audio-equipments")
+					.header(API_VERSION_HEADER_NAME, 1)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(pageSize))
+					.param("sort", sortOption.name())
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
+			.andExpect(jsonPath("$.content").isArray())
+			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
+		then(instrumentQueryService).should().findAudioEquipments(page, pageSize, sortOption);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
+	@Test
 	void 새로_등록할_일렉기타의_정보가_주어지면_일렉기타_매물을_등록한다() throws Exception {
 		// given
 		long sellerId = 1L;

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -239,6 +239,36 @@ class InstrumentControllerTest {
 	}
 
 	@Test
+	void 앰프_매물_목록을_조회한다() throws Exception {
+		// given
+		long userId = 1L;
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		Page<AmplifierDto> expectedResult = new PageImpl<>(List.of(
+			createAmplifierDto(2L, userId),
+			createAmplifierDto(3L, userId),
+			createAmplifierDto(4L, userId)
+		));
+		given(instrumentQueryService.findAmplifiers(page, pageSize, sortOption)).willReturn(expectedResult);
+
+		// when & then
+		mvc.perform(
+				get("/api/instruments/amplifiers")
+					.header(API_VERSION_HEADER_NAME, 1)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(pageSize))
+					.param("sort", sortOption.name())
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
+			.andExpect(jsonPath("$.content").isArray())
+			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
+		then(instrumentQueryService).should().findAmplifiers(page, pageSize, sortOption);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
+	@Test
 	void 새로_등록할_일렉기타의_정보가_주어지면_일렉기타_매물을_등록한다() throws Exception {
 		// given
 		long sellerId = 1L;

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -21,7 +21,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -100,7 +99,7 @@ class InstrumentControllerTest {
 			createBassGuitarDto(3L, userId),
 			createBassGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findInstruments(any(Pageable.class))).willReturn(expectedResult);
+		given(instrumentQueryService.findInstruments(pageNumber, pageSize, sortOption)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -114,7 +113,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
 			.andExpect(jsonPath("$.content").isArray())
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
-		then(instrumentQueryService).should().findInstruments(any(Pageable.class));
+		then(instrumentQueryService).should().findInstruments(pageNumber, pageSize, sortOption);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -130,7 +129,7 @@ class InstrumentControllerTest {
 			createElectricGuitarDto(3L, userId),
 			createElectricGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findElectricGuitars(any(Pageable.class))).willReturn(expectedResult);
+		given(instrumentQueryService.findElectricGuitars(pageNumber, pageSize, sortOption)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -144,7 +143,37 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
 			.andExpect(jsonPath("$.content").isArray())
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
-		then(instrumentQueryService).should().findElectricGuitars(any(Pageable.class));
+		then(instrumentQueryService).should().findElectricGuitars(pageNumber, pageSize, sortOption);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
+	@Test
+	void 베이스_기타_매물_목록을_조회한다() throws Exception {
+		// given
+		long userId = 1L;
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		Page<BassGuitarDto> expectedResult = new PageImpl<>(List.of(
+			createBassGuitarDto(2L, userId),
+			createBassGuitarDto(3L, userId),
+			createBassGuitarDto(4L, userId)
+		));
+		given(instrumentQueryService.findBassGuitars(page, pageSize, sortOption)).willReturn(expectedResult);
+
+		// when & then
+		mvc.perform(
+				get("/api/instruments/bass-guitars")
+					.header(API_VERSION_HEADER_NAME, 1)
+					.param("page", String.valueOf(page))
+					.param("size", String.valueOf(pageSize))
+					.param("sort", sortOption.name())
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
+			.andExpect(jsonPath("$.content").isArray())
+			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
+		then(instrumentQueryService).should().findBassGuitars(page, pageSize, sortOption);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -63,6 +63,7 @@ import com.ajou.hertz.domain.instrument.dto.request.CreateNewAudioEquipmentReque
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewEffectorRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
+import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.service.InstrumentCommandService;
 import com.ajou.hertz.domain.instrument.service.InstrumentQueryService;
 import com.ajou.hertz.domain.user.constant.Gender;
@@ -91,29 +92,31 @@ class InstrumentControllerTest {
 	void 전체_악기_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;
-		int pageNumber = 0;
+		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
 		Page<InstrumentDto> expectedResult = new PageImpl<>(List.of(
 			createBassGuitarDto(2L, userId),
 			createBassGuitarDto(3L, userId),
 			createBassGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findInstruments(pageNumber, pageSize, sortOption)).willReturn(expectedResult);
+		given(instrumentQueryService.findInstruments(page, pageSize, sortOption)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
 				get("/api/instruments")
 					.header(API_VERSION_HEADER_NAME, 1)
-					.param("page", String.valueOf(pageNumber))
+					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
+					.param("progress", filterConditions.getProgress().name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
 			.andExpect(jsonPath("$.content").isArray())
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
-		then(instrumentQueryService).should().findInstruments(pageNumber, pageSize, sortOption);
+		then(instrumentQueryService).should().findInstruments(page, pageSize, sortOption);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -121,29 +124,35 @@ class InstrumentControllerTest {
 	void 일렉_기타_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;
-		int pageNumber = 0;
+		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
 		Page<ElectricGuitarDto> expectedResult = new PageImpl<>(List.of(
 			createElectricGuitarDto(2L, userId),
 			createElectricGuitarDto(3L, userId),
 			createElectricGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findElectricGuitars(pageNumber, pageSize, sortOption)).willReturn(expectedResult);
+		given(instrumentQueryService.findElectricGuitars(
+			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+		)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
 				get("/api/instruments/electric-guitars")
 					.header(API_VERSION_HEADER_NAME, 1)
-					.param("page", String.valueOf(pageNumber))
+					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
+					.param("progress", filterConditions.getProgress().name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
 			.andExpect(jsonPath("$.content").isArray())
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
-		then(instrumentQueryService).should().findElectricGuitars(pageNumber, pageSize, sortOption);
+		then(instrumentQueryService)
+			.should()
+			.findElectricGuitars(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -153,13 +162,16 @@ class InstrumentControllerTest {
 		long userId = 1L;
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
 		Page<BassGuitarDto> expectedResult = new PageImpl<>(List.of(
 			createBassGuitarDto(2L, userId),
 			createBassGuitarDto(3L, userId),
 			createBassGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findBassGuitars(page, pageSize, sortOption)).willReturn(expectedResult);
+		given(instrumentQueryService.findBassGuitars(
+			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+		)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -168,12 +180,15 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
+					.param("progress", filterConditions.getProgress().name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
 			.andExpect(jsonPath("$.content").isArray())
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
-		then(instrumentQueryService).should().findBassGuitars(page, pageSize, sortOption);
+		then(instrumentQueryService)
+			.should()
+			.findBassGuitars(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -183,14 +198,16 @@ class InstrumentControllerTest {
 		long userId = 1L;
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
 		Page<AcousticAndClassicGuitarDto> expectedResult = new PageImpl<>(List.of(
 			createAcousticAndClassicGuitarDto(2L, userId),
 			createAcousticAndClassicGuitarDto(3L, userId),
 			createAcousticAndClassicGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findAcousticAndClassicGuitars(page, pageSize, sortOption))
-			.willReturn(expectedResult);
+		given(instrumentQueryService.findAcousticAndClassicGuitars(
+			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+		)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -199,12 +216,17 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
+					.param("progress", filterConditions.getProgress().name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
 			.andExpect(jsonPath("$.content").isArray())
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
-		then(instrumentQueryService).should().findAcousticAndClassicGuitars(page, pageSize, sortOption);
+		then(instrumentQueryService)
+			.should()
+			.findAcousticAndClassicGuitars(
+				eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+			);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -214,13 +236,16 @@ class InstrumentControllerTest {
 		long userId = 1L;
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
 		Page<EffectorDto> expectedResult = new PageImpl<>(List.of(
 			createEffectorDto(2L, userId),
 			createEffectorDto(3L, userId),
 			createEffectorDto(4L, userId)
 		));
-		given(instrumentQueryService.findEffectors(page, pageSize, sortOption)).willReturn(expectedResult);
+		given(instrumentQueryService.findEffectors(
+			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+		)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -229,12 +254,15 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
+					.param("progress", filterConditions.getProgress().name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
 			.andExpect(jsonPath("$.content").isArray())
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
-		then(instrumentQueryService).should().findEffectors(page, pageSize, sortOption);
+		then(instrumentQueryService)
+			.should()
+			.findEffectors(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -244,13 +272,16 @@ class InstrumentControllerTest {
 		long userId = 1L;
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
 		Page<AmplifierDto> expectedResult = new PageImpl<>(List.of(
 			createAmplifierDto(2L, userId),
 			createAmplifierDto(3L, userId),
 			createAmplifierDto(4L, userId)
 		));
-		given(instrumentQueryService.findAmplifiers(page, pageSize, sortOption)).willReturn(expectedResult);
+		given(instrumentQueryService.findAmplifiers(
+			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+		)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -259,12 +290,15 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
+					.param("progress", filterConditions.getProgress().name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
 			.andExpect(jsonPath("$.content").isArray())
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
-		then(instrumentQueryService).should().findAmplifiers(page, pageSize, sortOption);
+		then(instrumentQueryService)
+			.should()
+			.findAmplifiers(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -274,13 +308,16 @@ class InstrumentControllerTest {
 		long userId = 1L;
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
 		Page<AudioEquipmentDto> expectedResult = new PageImpl<>(List.of(
 			createAudioEquipmentDto(2L, userId),
 			createAudioEquipmentDto(3L, userId),
 			createAudioEquipmentDto(4L, userId)
 		));
-		given(instrumentQueryService.findAudioEquipments(page, pageSize, sortOption)).willReturn(expectedResult);
+		given(instrumentQueryService.findAudioEquipments(
+			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+		)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -289,12 +326,15 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
+					.param("progress", filterConditions.getProgress().name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
 			.andExpect(jsonPath("$.content").isArray())
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
-		then(instrumentQueryService).should().findAudioEquipments(page, pageSize, sortOption);
+		then(instrumentQueryService)
+			.should()
+			.findAudioEquipments(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -443,8 +483,8 @@ class InstrumentControllerTest {
 		CreateNewEffectorRequest request = createEffectorRequest();
 		EffectorDto expectedResult = createEffectorDto(2L, sellerId);
 		given(instrumentCommandService.createNewEffector(
-			eq(sellerId), any(CreateNewEffectorRequest.class))
-		).willReturn(expectedResult);
+			eq(sellerId), any(CreateNewEffectorRequest.class)
+		)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -485,8 +525,8 @@ class InstrumentControllerTest {
 		CreateNewAmplifierRequest request = createAmplifierRequest();
 		AmplifierDto expectedResult = createAmplifierDto(2L, sellerId);
 		given(instrumentCommandService.createNewAmplifier(
-			eq(sellerId), any(CreateNewAmplifierRequest.class))
-		).willReturn(expectedResult);
+			eq(sellerId), any(CreateNewAmplifierRequest.class)
+		)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -528,8 +568,8 @@ class InstrumentControllerTest {
 		CreateNewAudioEquipmentRequest request = createAudioEquipmentRequest();
 		AudioEquipmentDto expectedResult = createAudioEquipmentDto(2L, sellerId);
 		given(instrumentCommandService.createNewAudioEquipment(
-			eq(sellerId), any(CreateNewAudioEquipmentRequest.class))
-		).willReturn(expectedResult);
+			eq(sellerId), any(CreateNewAudioEquipmentRequest.class)
+		)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -815,11 +855,12 @@ class InstrumentControllerTest {
 	}
 
 	private CreateNewElectricGuitarRequest createElectricGuitarRequest() throws Exception {
-		Constructor<CreateNewElectricGuitarRequest> createNewElectricGuitarRequestConstructor = CreateNewElectricGuitarRequest.class.getDeclaredConstructor(
-			String.class, List.class, InstrumentProgressStatus.class, AddressRequest.class,
-			Short.class, Integer.class, Boolean.class, String.class, ElectricGuitarBrand.class,
-			ElectricGuitarModel.class, Short.class, GuitarColor.class, List.class
-		);
+		Constructor<CreateNewElectricGuitarRequest> createNewElectricGuitarRequestConstructor =
+			CreateNewElectricGuitarRequest.class.getDeclaredConstructor(
+				String.class, List.class, InstrumentProgressStatus.class, AddressRequest.class,
+				Short.class, Integer.class, Boolean.class, String.class, ElectricGuitarBrand.class,
+				ElectricGuitarModel.class, Short.class, GuitarColor.class, List.class
+			);
 		createNewElectricGuitarRequestConstructor.setAccessible(true);
 		return createNewElectricGuitarRequestConstructor.newInstance(
 			"Test electric guitar",
@@ -955,6 +996,15 @@ class InstrumentControllerTest {
 			List.of(createMultipartFile(), createMultipartFile(), createMultipartFile(), createMultipartFile()),
 			List.of("Fender", "Guitar"),
 			AudioEquipmentType.AUDIO_EQUIPMENT
+		);
+	}
+
+	private InstrumentFilterConditions createInstrumentFilterConditions() throws Exception {
+		Constructor<InstrumentFilterConditions> instrumentFilterConditionsConstructor =
+			InstrumentFilterConditions.class.getDeclaredConstructor(InstrumentProgressStatus.class);
+		instrumentFilterConditionsConstructor.setAccessible(true);
+		return instrumentFilterConditionsConstructor.newInstance(
+			InstrumentProgressStatus.SELLING
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -20,6 +20,10 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import com.ajou.hertz.common.entity.Address;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarModel;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
@@ -28,9 +32,11 @@ import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
@@ -131,6 +137,33 @@ class InstrumentQueryServiceTest {
 		);
 	}
 
+	@Test
+	void 어쿠스틱_클래식_기타_목록을_조회한다() throws Exception {
+		// given
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
+		User user = createUser();
+		Page<AcousticAndClassicGuitar> expectedResult = new PageImpl<>(List.of(
+			createAcousticAndClassicGuitar(1L, user),
+			createAcousticAndClassicGuitar(2L, user),
+			createAcousticAndClassicGuitar(3L, user)
+		));
+		given(instrumentRepository.findAcousticAndClassicGuitars(page, pageSize, sort)).willReturn(expectedResult);
+
+		// when
+		Page<AcousticAndClassicGuitarDto> actualResult = sut.findAcousticAndClassicGuitars(page, pageSize, sort);
+
+		// then
+		then(instrumentRepository).should().findAcousticAndClassicGuitars(page, pageSize, sort);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
+		assertIterableEquals(
+			expectedResult.getContent().stream().map(AcousticAndClassicGuitar::getId).toList(),
+			actualResult.getContent().stream().map(AcousticAndClassicGuitarDto::getId).toList()
+		);
+	}
+
 	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
 		then(instrumentRepository).shouldHaveNoMoreInteractions();
 	}
@@ -228,6 +261,32 @@ class InstrumentQueryServiceTest {
 			Gender.ETC,
 			"01012345678",
 			null
+		);
+	}
+
+	private AcousticAndClassicGuitar createAcousticAndClassicGuitar(long id, User seller) throws Exception {
+		Constructor<AcousticAndClassicGuitar> acousticAndClassicGuitarConstructor =
+			AcousticAndClassicGuitar.class.getDeclaredConstructor(
+				Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+				Short.class, Integer.class, Boolean.class, String.class,
+				AcousticAndClassicGuitarBrand.class, AcousticAndClassicGuitarModel.class,
+				AcousticAndClassicGuitarWood.class, AcousticAndClassicGuitarPickUp.class
+			);
+		acousticAndClassicGuitarConstructor.setAccessible(true);
+		return acousticAndClassicGuitarConstructor.newInstance(
+			id,
+			seller,
+			"Test electric guitar",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			AcousticAndClassicGuitarBrand.HEX,
+			AcousticAndClassicGuitarModel.JUMBO_BODY,
+			AcousticAndClassicGuitarWood.PLYWOOD,
+			AcousticAndClassicGuitarPickUp.MICROPHONE
 		);
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -45,6 +45,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
@@ -100,6 +101,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<ElectricGuitar> expectedResult = new PageImpl<>(List.of(
@@ -107,13 +109,14 @@ class InstrumentQueryServiceTest {
 			createElectricGuitar(2L, user),
 			createElectricGuitar(3L, user)
 		));
-		given(instrumentRepository.findElectricGuitars(page, pageSize, sort)).willReturn(expectedResult);
+		given(instrumentRepository.findElectricGuitars(page, pageSize, sort, filterConditions))
+			.willReturn(expectedResult);
 
 		// when
-		Page<ElectricGuitarDto> actualResult = sut.findElectricGuitars(page, pageSize, sort);
+		Page<ElectricGuitarDto> actualResult = sut.findElectricGuitars(page, pageSize, sort, filterConditions);
 
 		// then
-		then(instrumentRepository).should().findElectricGuitars(page, pageSize, sort);
+		then(instrumentRepository).should().findElectricGuitars(page, pageSize, sort, filterConditions);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
 		assertIterableEquals(
@@ -127,6 +130,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<BassGuitar> expectedResult = new PageImpl<>(List.of(
@@ -134,13 +138,13 @@ class InstrumentQueryServiceTest {
 			createBassGuitar(2L, user),
 			createBassGuitar(3L, user)
 		));
-		given(instrumentRepository.findBassGuitars(page, pageSize, sort)).willReturn(expectedResult);
+		given(instrumentRepository.findBassGuitars(page, pageSize, sort, filterConditions)).willReturn(expectedResult);
 
 		// when
-		Page<BassGuitarDto> actualResult = sut.findBassGuitars(page, pageSize, sort);
+		Page<BassGuitarDto> actualResult = sut.findBassGuitars(page, pageSize, sort, filterConditions);
 
 		// then
-		then(instrumentRepository).should().findBassGuitars(page, pageSize, sort);
+		then(instrumentRepository).should().findBassGuitars(page, pageSize, sort, filterConditions);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
 		assertIterableEquals(
@@ -154,6 +158,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<AcousticAndClassicGuitar> expectedResult = new PageImpl<>(List.of(
@@ -161,13 +166,15 @@ class InstrumentQueryServiceTest {
 			createAcousticAndClassicGuitar(2L, user),
 			createAcousticAndClassicGuitar(3L, user)
 		));
-		given(instrumentRepository.findAcousticAndClassicGuitars(page, pageSize, sort)).willReturn(expectedResult);
+		given(instrumentRepository.findAcousticAndClassicGuitars(page, pageSize, sort, filterConditions))
+			.willReturn(expectedResult);
 
 		// when
-		Page<AcousticAndClassicGuitarDto> actualResult = sut.findAcousticAndClassicGuitars(page, pageSize, sort);
+		Page<AcousticAndClassicGuitarDto> actualResult =
+			sut.findAcousticAndClassicGuitars(page, pageSize, sort, filterConditions);
 
 		// then
-		then(instrumentRepository).should().findAcousticAndClassicGuitars(page, pageSize, sort);
+		then(instrumentRepository).should().findAcousticAndClassicGuitars(page, pageSize, sort, filterConditions);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
 		assertIterableEquals(
@@ -181,6 +188,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<Effector> expectedResult = new PageImpl<>(List.of(
@@ -188,13 +196,13 @@ class InstrumentQueryServiceTest {
 			createEffector(2L, user),
 			createEffector(3L, user)
 		));
-		given(instrumentRepository.findEffectors(page, pageSize, sort)).willReturn(expectedResult);
+		given(instrumentRepository.findEffectors(page, pageSize, sort, filterConditions)).willReturn(expectedResult);
 
 		// when
-		Page<EffectorDto> actualResult = sut.findEffectors(page, pageSize, sort);
+		Page<EffectorDto> actualResult = sut.findEffectors(page, pageSize, sort, filterConditions);
 
 		// then
-		then(instrumentRepository).should().findEffectors(page, pageSize, sort);
+		then(instrumentRepository).should().findEffectors(page, pageSize, sort, filterConditions);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
 		assertIterableEquals(
@@ -208,6 +216,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<Amplifier> expectedResult = new PageImpl<>(List.of(
@@ -215,13 +224,13 @@ class InstrumentQueryServiceTest {
 			createAmplifier(2L, user),
 			createAmplifier(3L, user)
 		));
-		given(instrumentRepository.findAmplifiers(page, pageSize, sort)).willReturn(expectedResult);
+		given(instrumentRepository.findAmplifiers(page, pageSize, sort, filterConditions)).willReturn(expectedResult);
 
 		// when
-		Page<AmplifierDto> actualResult = sut.findAmplifiers(page, pageSize, sort);
+		Page<AmplifierDto> actualResult = sut.findAmplifiers(page, pageSize, sort, filterConditions);
 
 		// then
-		then(instrumentRepository).should().findAmplifiers(page, pageSize, sort);
+		then(instrumentRepository).should().findAmplifiers(page, pageSize, sort, filterConditions);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
 		assertIterableEquals(
@@ -235,6 +244,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
+		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<AudioEquipment> expectedResult = new PageImpl<>(List.of(
@@ -242,13 +252,14 @@ class InstrumentQueryServiceTest {
 			createAudioEquipment(2L, user),
 			createAudioEquipment(3L, user)
 		));
-		given(instrumentRepository.findAudioEquipments(page, pageSize, sort)).willReturn(expectedResult);
+		given(instrumentRepository.findAudioEquipments(page, pageSize, sort, filterConditions))
+			.willReturn(expectedResult);
 
 		// when
-		Page<AudioEquipmentDto> actualResult = sut.findAudioEquipments(page, pageSize, sort);
+		Page<AudioEquipmentDto> actualResult = sut.findAudioEquipments(page, pageSize, sort, filterConditions);
 
 		// then
-		then(instrumentRepository).should().findAudioEquipments(page, pageSize, sort);
+		then(instrumentRepository).should().findAudioEquipments(page, pageSize, sort, filterConditions);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
 		assertIterableEquals(
@@ -451,5 +462,12 @@ class InstrumentQueryServiceTest {
 
 	private User createUser() throws Exception {
 		return createUser(1L);
+	}
+
+	private InstrumentFilterConditions createInstrumentFilterConditions() throws Exception {
+		Constructor<InstrumentFilterConditions> instrumentFilterConditionsConstructor =
+			InstrumentFilterConditions.class.getDeclaredConstructor();
+		instrumentFilterConditionsConstructor.setAccessible(true);
+		return instrumentFilterConditionsConstructor.newInstance();
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -27,6 +27,7 @@ import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
 import com.ajou.hertz.domain.instrument.constant.AmplifierBrand;
 import com.ajou.hertz.domain.instrument.constant.AmplifierType;
 import com.ajou.hertz.domain.instrument.constant.AmplifierUsage;
+import com.ajou.hertz.domain.instrument.constant.AudioEquipmentType;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
@@ -39,12 +40,14 @@ import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.AmplifierDto;
+import com.ajou.hertz.domain.instrument.dto.AudioEquipmentDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
+import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
@@ -227,6 +230,33 @@ class InstrumentQueryServiceTest {
 		);
 	}
 
+	@Test
+	void 음향_장비_목록을_조회한다() throws Exception {
+		// given
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
+		User user = createUser();
+		Page<AudioEquipment> expectedResult = new PageImpl<>(List.of(
+			createAudioEquipment(1L, user),
+			createAudioEquipment(2L, user),
+			createAudioEquipment(3L, user)
+		));
+		given(instrumentRepository.findAudioEquipments(page, pageSize, sort)).willReturn(expectedResult);
+
+		// when
+		Page<AudioEquipmentDto> actualResult = sut.findAudioEquipments(page, pageSize, sort);
+
+		// then
+		then(instrumentRepository).should().findAudioEquipments(page, pageSize, sort);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
+		assertIterableEquals(
+			expectedResult.getContent().stream().map(AudioEquipment::getId).toList(),
+			actualResult.getContent().stream().map(AudioEquipmentDto::getId).toList()
+		);
+	}
+
 	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
 		then(instrumentRepository).shouldHaveNoMoreInteractions();
 	}
@@ -395,6 +425,27 @@ class InstrumentQueryServiceTest {
 			AmplifierType.GUITAR,
 			AmplifierBrand.FENDER,
 			AmplifierUsage.HOME
+		);
+	}
+
+	private AudioEquipment createAudioEquipment(long id, User seller) throws Exception {
+		Constructor<AudioEquipment> audioEquipmentConstructor = AudioEquipment.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+			Short.class, Integer.class, Boolean.class, String.class,
+			AudioEquipmentType.class
+		);
+		audioEquipmentConstructor.setAccessible(true);
+		return audioEquipmentConstructor.newInstance(
+			id,
+			seller,
+			"Title",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			AudioEquipmentType.AUDIO_EQUIPMENT
 		);
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -27,6 +27,8 @@ import com.ajou.hertz.domain.instrument.constant.ElectricGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
@@ -51,6 +53,9 @@ class InstrumentQueryServiceTest {
 	@Test
 	void 종류_상관_없이_전체_악기_목록을_조회한다() throws Exception {
 		// given
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<Instrument> expectedResult = new PageImpl<>(List.of(
 			createInstrument(1L, user),
@@ -60,7 +65,7 @@ class InstrumentQueryServiceTest {
 		given(instrumentRepository.findAll(any(Pageable.class))).willReturn(expectedResult);
 
 		// when
-		Page<InstrumentDto> actualResult = sut.findInstruments(Pageable.ofSize(10));
+		Page<InstrumentDto> actualResult = sut.findInstruments(page, pageSize, sort);
 
 		// then
 		then(instrumentRepository).should().findAll(any(Pageable.class));
@@ -75,24 +80,54 @@ class InstrumentQueryServiceTest {
 	@Test
 	void 일렉_기타_목록을_조회한다() throws Exception {
 		// given
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<ElectricGuitar> expectedResult = new PageImpl<>(List.of(
 			createElectricGuitar(1L, user),
 			createElectricGuitar(2L, user),
 			createElectricGuitar(3L, user)
 		));
-		given(instrumentRepository.findElectricGuitars(any(Pageable.class))).willReturn(expectedResult);
+		given(instrumentRepository.findElectricGuitars(page, pageSize, sort)).willReturn(expectedResult);
 
 		// when
-		Page<ElectricGuitarDto> actualResult = sut.findElectricGuitars(Pageable.ofSize(10));
+		Page<ElectricGuitarDto> actualResult = sut.findElectricGuitars(page, pageSize, sort);
 
 		// then
-		then(instrumentRepository).should().findElectricGuitars(any(Pageable.class));
+		then(instrumentRepository).should().findElectricGuitars(page, pageSize, sort);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
 		assertIterableEquals(
 			expectedResult.getContent().stream().map(ElectricGuitar::getId).toList(),
 			actualResult.getContent().stream().map(ElectricGuitarDto::getId).toList()
+		);
+	}
+
+	@Test
+	void 베이스_기타_목록을_조회한다() throws Exception {
+		// given
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
+		User user = createUser();
+		Page<BassGuitar> expectedResult = new PageImpl<>(List.of(
+			createBassGuitar(1L, user),
+			createBassGuitar(2L, user),
+			createBassGuitar(3L, user)
+		));
+		given(instrumentRepository.findBassGuitars(page, pageSize, sort)).willReturn(expectedResult);
+
+		// when
+		Page<BassGuitarDto> actualResult = sut.findBassGuitars(page, pageSize, sort);
+
+		// then
+		then(instrumentRepository).should().findBassGuitars(page, pageSize, sort);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
+		assertIterableEquals(
+			expectedResult.getContent().stream().map(BassGuitar::getId).toList(),
+			actualResult.getContent().stream().map(BassGuitarDto::getId).toList()
 		);
 	}
 
@@ -148,6 +183,30 @@ class InstrumentQueryServiceTest {
 			ElectricGuitarBrand.FENDER_USA,
 			ElectricGuitarModel.TELECASTER,
 			(short)2014,
+			GuitarColor.RED
+		);
+	}
+
+	private BassGuitar createBassGuitar(long id, User seller) throws Exception {
+		Constructor<BassGuitar> bassGuitarConstructor = BassGuitar.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+			Short.class, Integer.class, Boolean.class, String.class,
+			BassGuitarBrand.class, BassGuitarPickUp.class, BassGuitarPreAmplifier.class, GuitarColor.class
+		);
+		bassGuitarConstructor.setAccessible(true);
+		return bassGuitarConstructor.newInstance(
+			id,
+			seller,
+			"Test electric guitar",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			BassGuitarBrand.FENDER,
+			BassGuitarPickUp.JAZZ,
+			BassGuitarPreAmplifier.ACTIVE,
 			GuitarColor.RED
 		);
 	}

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -27,6 +27,8 @@ import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.EffectorFeature;
+import com.ajou.hertz.domain.instrument.constant.EffectorType;
 import com.ajou.hertz.domain.instrument.constant.ElectricGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
@@ -34,10 +36,12 @@ import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
@@ -164,6 +168,33 @@ class InstrumentQueryServiceTest {
 		);
 	}
 
+	@Test
+	void 이펙터_목록을_조회한다() throws Exception {
+		// given
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
+		User user = createUser();
+		Page<Effector> expectedResult = new PageImpl<>(List.of(
+			createEffector(1L, user),
+			createEffector(2L, user),
+			createEffector(3L, user)
+		));
+		given(instrumentRepository.findEffectors(page, pageSize, sort)).willReturn(expectedResult);
+
+		// when
+		Page<EffectorDto> actualResult = sut.findEffectors(page, pageSize, sort);
+
+		// then
+		then(instrumentRepository).should().findEffectors(page, pageSize, sort);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
+		assertIterableEquals(
+			expectedResult.getContent().stream().map(Effector::getId).toList(),
+			actualResult.getContent().stream().map(EffectorDto::getId).toList()
+		);
+	}
+
 	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
 		then(instrumentRepository).shouldHaveNoMoreInteractions();
 	}
@@ -287,6 +318,28 @@ class InstrumentQueryServiceTest {
 			AcousticAndClassicGuitarModel.JUMBO_BODY,
 			AcousticAndClassicGuitarWood.PLYWOOD,
 			AcousticAndClassicGuitarPickUp.MICROPHONE
+		);
+	}
+
+	private Effector createEffector(long id, User seller) throws Exception {
+		Constructor<Effector> effectorConstructor = Effector.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+			Short.class, Integer.class, Boolean.class, String.class,
+			EffectorType.class, EffectorFeature.class
+		);
+		effectorConstructor.setAccessible(true);
+		return effectorConstructor.newInstance(
+			id,
+			seller,
+			"Title",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			EffectorType.GUITAR,
+			EffectorFeature.ETC
 		);
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -24,6 +24,9 @@ import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
+import com.ajou.hertz.domain.instrument.constant.AmplifierBrand;
+import com.ajou.hertz.domain.instrument.constant.AmplifierType;
+import com.ajou.hertz.domain.instrument.constant.AmplifierUsage;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
@@ -35,11 +38,13 @@ import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.AmplifierDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
+import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
@@ -195,6 +200,33 @@ class InstrumentQueryServiceTest {
 		);
 	}
 
+	@Test
+	void 앰프_목록을_조회한다() throws Exception {
+		// given
+		int page = 0;
+		int pageSize = 10;
+		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
+		User user = createUser();
+		Page<Amplifier> expectedResult = new PageImpl<>(List.of(
+			createAmplifier(1L, user),
+			createAmplifier(2L, user),
+			createAmplifier(3L, user)
+		));
+		given(instrumentRepository.findAmplifiers(page, pageSize, sort)).willReturn(expectedResult);
+
+		// when
+		Page<AmplifierDto> actualResult = sut.findAmplifiers(page, pageSize, sort);
+
+		// then
+		then(instrumentRepository).should().findAmplifiers(page, pageSize, sort);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
+		assertIterableEquals(
+			expectedResult.getContent().stream().map(Amplifier::getId).toList(),
+			actualResult.getContent().stream().map(AmplifierDto::getId).toList()
+		);
+	}
+
 	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
 		then(instrumentRepository).shouldHaveNoMoreInteractions();
 	}
@@ -340,6 +372,29 @@ class InstrumentQueryServiceTest {
 			"description",
 			EffectorType.GUITAR,
 			EffectorFeature.ETC
+		);
+	}
+
+	private Amplifier createAmplifier(long id, User seller) throws Exception {
+		Constructor<Amplifier> amplifierConstructor = Amplifier.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class,
+			Short.class, Integer.class, Boolean.class, String.class,
+			AmplifierType.class, AmplifierBrand.class, AmplifierUsage.class
+		);
+		amplifierConstructor.setAccessible(true);
+		return amplifierConstructor.newInstance(
+			id,
+			seller,
+			"Title",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			AmplifierType.GUITAR,
+			AmplifierBrand.FENDER,
+			AmplifierUsage.HOME
 		);
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -23,10 +23,14 @@ import com.ajou.hertz.common.entity.Address;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.ElectricGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
 import com.ajou.hertz.domain.instrument.service.InstrumentQueryService;
@@ -68,6 +72,30 @@ class InstrumentQueryServiceTest {
 		);
 	}
 
+	@Test
+	void 일렉_기타_목록을_조회한다() throws Exception {
+		// given
+		User user = createUser();
+		Page<ElectricGuitar> expectedResult = new PageImpl<>(List.of(
+			createElectricGuitar(1L, user),
+			createElectricGuitar(2L, user),
+			createElectricGuitar(3L, user)
+		));
+		given(instrumentRepository.findElectricGuitars(any(Pageable.class))).willReturn(expectedResult);
+
+		// when
+		Page<ElectricGuitarDto> actualResult = sut.findElectricGuitars(Pageable.ofSize(10));
+
+		// then
+		then(instrumentRepository).should().findElectricGuitars(any(Pageable.class));
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult.getNumberOfElements()).isEqualTo(actualResult.getNumberOfElements());
+		assertIterableEquals(
+			expectedResult.getContent().stream().map(ElectricGuitar::getId).toList(),
+			actualResult.getContent().stream().map(ElectricGuitarDto::getId).toList()
+		);
+	}
+
 	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
 		then(instrumentRepository).shouldHaveNoMoreInteractions();
 	}
@@ -96,6 +124,30 @@ class InstrumentQueryServiceTest {
 			BassGuitarBrand.FENDER,
 			BassGuitarPickUp.JAZZ,
 			BassGuitarPreAmplifier.ACTIVE,
+			GuitarColor.RED
+		);
+	}
+
+	private ElectricGuitar createElectricGuitar(long id, User seller) throws Exception {
+		Constructor<ElectricGuitar> electricGuitarConstructor = ElectricGuitar.class.getDeclaredConstructor(
+			Long.class, User.class, String.class, InstrumentProgressStatus.class, Address.class, Short.class,
+			Integer.class, Boolean.class, String.class, ElectricGuitarBrand.class, ElectricGuitarModel.class,
+			Short.class, GuitarColor.class
+		);
+		electricGuitarConstructor.setAccessible(true);
+		return electricGuitarConstructor.newInstance(
+			id,
+			seller,
+			"Test electric guitar",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			ElectricGuitarBrand.FENDER_USA,
+			ElectricGuitarModel.TELECASTER,
+			(short)2014,
 			GuitarColor.RED
 		);
 	}


### PR DESCRIPTION
## 🔥 Related Issue
- #67

## 🏃‍ Task
- Querydsl 의존성 및 설정 추가
- Jacoco test coverage  대상에 repository layer 추가
- 종류별 악기 목록 조회 API 구현
  - 각 악기 종류별 필터링 항목은 다음 작업에 추가 예정
  -  일렉 기타 목록 조회 API 구현
  -  베이스 기타 목록 조회 API 구현
  -  어쿠스틱&클래식 기타 목록 조회 API 구현
  -  이펙터 목록 조회 API 구현
  -  앰프 목록 조회 API 구현
  -  음향 장비 목록 조회 API 구현

## 📄 Reference
- None
