### PR TITLE
종류별 악기 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -26,6 +26,7 @@ import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
@@ -222,7 +223,7 @@ public class InstrumentController {
 		@Parameter(
 			description = "정렬 기준"
 		) @RequestParam InstrumentSortOption sort,
-		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
+		@ParameterObject @Valid @ModelAttribute AudioEquipmentFilterConditions filterConditions
 	) {
 		return instrumentQueryService
 			.findAudioEquipments(page, size, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -32,6 +32,7 @@ import com.ajou.hertz.domain.instrument.dto.request.CreateNewAudioEquipmentReque
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewEffectorRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
+import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.response.AcousticAndClassicGuitarResponse;
@@ -172,7 +173,7 @@ public class InstrumentController {
 		@Parameter(
 			description = "정렬 기준"
 		) @RequestParam InstrumentSortOption sort,
-		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
+		@ParameterObject @Valid @ModelAttribute EffectorFilterConditions filterConditions
 	) {
 		return instrumentQueryService
 			.findEffectors(page, size, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -30,6 +30,7 @@ import com.ajou.hertz.domain.instrument.dto.request.CreateNewAudioEquipmentReque
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewEffectorRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
+import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.response.AcousticAndClassicGuitarResponse;
 import com.ajou.hertz.domain.instrument.dto.response.AmplifierResponse;
@@ -97,7 +98,7 @@ public class InstrumentController {
 		@Parameter(
 			description = "정렬 기준"
 		) @RequestParam InstrumentSortOption sort,
-		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
+		@ParameterObject @Valid @ModelAttribute ElectricGuitarFilterConditions filterConditions
 	) {
 		return instrumentQueryService
 			.findElectricGuitars(page, size, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -24,6 +24,7 @@ import com.ajou.hertz.domain.instrument.dto.AudioEquipmentDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
@@ -147,7 +148,7 @@ public class InstrumentController {
 		@Parameter(
 			description = "정렬 기준"
 		) @RequestParam InstrumentSortOption sort,
-		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
+		@ParameterObject @Valid @ModelAttribute AcousticAndClassicGuitarFilterConditions filterConditions
 	) {
 		return instrumentQueryService
 			.findAcousticAndClassicGuitars(page, size, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -24,6 +24,7 @@ import com.ajou.hertz.domain.instrument.dto.AudioEquipmentDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAudioEquipmentRequest;
@@ -122,7 +123,7 @@ public class InstrumentController {
 		@Parameter(
 			description = "정렬 기준"
 		) @RequestParam InstrumentSortOption sort,
-		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
+		@ParameterObject @Valid @ModelAttribute BassGuitarFilterConditions filterConditions
 	) {
 		return instrumentQueryService
 			.findBassGuitars(page, size, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -25,6 +25,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
@@ -197,7 +198,7 @@ public class InstrumentController {
 		@Parameter(
 			description = "정렬 기준"
 		) @RequestParam InstrumentSortOption sort,
-		@ParameterObject @Valid @ModelAttribute InstrumentFilterConditions filterConditions
+		@ParameterObject @Valid @ModelAttribute AmplifierFilterConditions filterConditions
 	) {
 		return instrumentQueryService
 			.findAmplifiers(page, size, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/AcousticAndClassicGuitarFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/AcousticAndClassicGuitarFilterConditions.java
@@ -1,0 +1,39 @@
+package com.ajou.hertz.domain.instrument.dto.request;
+
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarModel;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter    // for @ModelAttribute
+@Getter
+public class AcousticAndClassicGuitarFilterConditions extends InstrumentFilterConditions {
+
+	private AcousticAndClassicGuitarBrand brand;
+	private AcousticAndClassicGuitarModel model;
+	private AcousticAndClassicGuitarWood wood;
+	private AcousticAndClassicGuitarPickUp pickUp;
+
+	private AcousticAndClassicGuitarFilterConditions(
+		InstrumentProgressStatus progress,
+		String sido,
+		String sgg,
+		AcousticAndClassicGuitarBrand brand,
+		AcousticAndClassicGuitarModel model,
+		AcousticAndClassicGuitarWood wood,
+		AcousticAndClassicGuitarPickUp pickUp
+	) {
+		super(progress, sido, sgg);
+		this.brand = brand;
+		this.model = model;
+		this.wood = wood;
+		this.pickUp = pickUp;
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/AmplifierFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/AmplifierFilterConditions.java
@@ -1,0 +1,35 @@
+package com.ajou.hertz.domain.instrument.dto.request;
+
+import com.ajou.hertz.domain.instrument.constant.AmplifierBrand;
+import com.ajou.hertz.domain.instrument.constant.AmplifierType;
+import com.ajou.hertz.domain.instrument.constant.AmplifierUsage;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter    // for @ModelAttribute
+@Getter
+public class AmplifierFilterConditions extends InstrumentFilterConditions {
+
+	private AmplifierType type;
+	private AmplifierBrand brand;
+	private AmplifierUsage usage;
+
+	private AmplifierFilterConditions(
+		InstrumentProgressStatus progress,
+		String sido,
+		String sgg,
+		AmplifierType type,
+		AmplifierBrand brand,
+		AmplifierUsage usage
+	) {
+		super(progress, sido, sgg);
+		this.type = type;
+		this.brand = brand;
+		this.usage = usage;
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/AudioEquipmentFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/AudioEquipmentFilterConditions.java
@@ -1,0 +1,27 @@
+package com.ajou.hertz.domain.instrument.dto.request;
+
+import com.ajou.hertz.domain.instrument.constant.AudioEquipmentType;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter    // for @ModelAttribute
+@Getter
+public class AudioEquipmentFilterConditions extends InstrumentFilterConditions {
+
+	private AudioEquipmentType type;
+
+	private AudioEquipmentFilterConditions(
+		InstrumentProgressStatus progress,
+		String sido,
+		String sgg,
+		AudioEquipmentType type
+	) {
+		super(progress, sido, sgg);
+		this.type = type;
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/BassGuitarFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/BassGuitarFilterConditions.java
@@ -1,0 +1,39 @@
+package com.ajou.hertz.domain.instrument.dto.request;
+
+import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.GuitarColor;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter    // for @ModelAttribute
+@Getter
+public class BassGuitarFilterConditions extends InstrumentFilterConditions {
+
+	private BassGuitarBrand brand;
+	private BassGuitarPickUp pickUp;
+	private BassGuitarPreAmplifier preAmplifier;
+	private GuitarColor color;
+
+	public BassGuitarFilterConditions(
+		InstrumentProgressStatus progress,
+		String sido,
+		String sgg,
+		BassGuitarBrand brand,
+		BassGuitarPickUp pickUp,
+		BassGuitarPreAmplifier preAmplifier,
+		GuitarColor color
+	) {
+		super(progress, sido, sgg);
+		this.brand = brand;
+		this.pickUp = pickUp;
+		this.preAmplifier = preAmplifier;
+		this.color = color;
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/BassGuitarFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/BassGuitarFilterConditions.java
@@ -21,7 +21,7 @@ public class BassGuitarFilterConditions extends InstrumentFilterConditions {
 	private BassGuitarPreAmplifier preAmplifier;
 	private GuitarColor color;
 
-	public BassGuitarFilterConditions(
+	private BassGuitarFilterConditions(
 		InstrumentProgressStatus progress,
 		String sido,
 		String sgg,

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/EffectorFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/EffectorFilterConditions.java
@@ -1,0 +1,31 @@
+package com.ajou.hertz.domain.instrument.dto.request;
+
+import com.ajou.hertz.domain.instrument.constant.EffectorFeature;
+import com.ajou.hertz.domain.instrument.constant.EffectorType;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter    // for @ModelAttribute
+@Getter
+public class EffectorFilterConditions extends InstrumentFilterConditions {
+
+	private EffectorType type;
+	private EffectorFeature feature;
+
+	private EffectorFilterConditions(
+		InstrumentProgressStatus progress,
+		String sido,
+		String sgg,
+		EffectorType type,
+		EffectorFeature feature
+	) {
+		super(progress, sido, sgg);
+		this.type = type;
+		this.feature = feature;
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/ElectricGuitarFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/ElectricGuitarFilterConditions.java
@@ -19,7 +19,7 @@ public class ElectricGuitarFilterConditions extends InstrumentFilterConditions {
 	private ElectricGuitarModel model;
 	private GuitarColor color;
 
-	public ElectricGuitarFilterConditions(
+	private ElectricGuitarFilterConditions(
 		InstrumentProgressStatus progress,
 		String sido,
 		String sgg,

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/ElectricGuitarFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/ElectricGuitarFilterConditions.java
@@ -1,0 +1,35 @@
+package com.ajou.hertz.domain.instrument.dto.request;
+
+import com.ajou.hertz.domain.instrument.constant.ElectricGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
+import com.ajou.hertz.domain.instrument.constant.GuitarColor;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter    // for @ModelAttribute
+@Getter
+public class ElectricGuitarFilterConditions extends InstrumentFilterConditions {
+
+	private ElectricGuitarBrand brand;
+	private ElectricGuitarModel model;
+	private GuitarColor color;
+
+	public ElectricGuitarFilterConditions(
+		InstrumentProgressStatus progress,
+		String sido,
+		String sgg,
+		ElectricGuitarBrand brand,
+		ElectricGuitarModel model,
+		GuitarColor color
+	) {
+		super(progress, sido, sgg);
+		this.brand = brand;
+		this.model = model;
+		this.color = color;
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/InstrumentFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/InstrumentFilterConditions.java
@@ -2,17 +2,24 @@ package com.ajou.hertz.domain.instrument.dto.request;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Setter    // for @ModelAttribute
 @Getter
-public class InstrumentFilterConditions {
+public class InstrumentFilterConditions {    // TODO: abstract class로 전환
 
 	private InstrumentProgressStatus progress;
+
+	@Schema(description = "거래 지역 - 시/도", example = "서울특별시")
+	private String sido;
+
+	@Schema(description = "거래 지역 - 시/군/구", example = "종로구")
+	private String sgg;
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/request/InstrumentFilterConditions.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/request/InstrumentFilterConditions.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Setter    // for @ModelAttribute
 @Getter
-public class InstrumentFilterConditions {    // TODO: abstract class로 전환
+public class InstrumentFilterConditions {
 
 	private InstrumentProgressStatus progress;
 

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
@@ -29,7 +30,7 @@ public interface InstrumentRepositoryCustom {
 	);
 
 	Page<Effector> findEffectors(
-		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+		int page, int pageSize, InstrumentSortOption sort, EffectorFilterConditions filterConditions
 	);
 
 	Page<Amplifier> findAmplifiers(

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
@@ -34,7 +35,7 @@ public interface InstrumentRepositoryCustom {
 	);
 
 	Page<Amplifier> findAmplifiers(
-		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+		int page, int pageSize, InstrumentSortOption sort, AmplifierFilterConditions filterConditions
 	);
 
 	Page<AudioEquipment> findAudioEquipments(

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.ajou.hertz.domain.instrument.repository;
 import org.springframework.data.domain.Page;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
@@ -14,7 +15,7 @@ import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 public interface InstrumentRepositoryCustom {
 
 	Page<ElectricGuitar> findElectricGuitars(
-		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+		int page, int pageSize, InstrumentSortOption sort, ElectricGuitarFilterConditions filterConditions
 	);
 
 	Page<BassGuitar> findBassGuitars(

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.ajou.hertz.domain.instrument.repository;
 import org.springframework.data.domain.Page;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
@@ -24,7 +25,7 @@ public interface InstrumentRepositoryCustom {
 	);
 
 	Page<AcousticAndClassicGuitar> findAcousticAndClassicGuitars(
-		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+		int page, int pageSize, InstrumentSortOption sort, AcousticAndClassicGuitarFilterConditions filterConditions
 	);
 
 	Page<Effector> findEffectors(

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -5,10 +5,10 @@ import org.springframework.data.domain.Page;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
-import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
@@ -39,6 +39,6 @@ public interface InstrumentRepositoryCustom {
 	);
 
 	Page<AudioEquipment> findAudioEquipments(
-		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+		int page, int pageSize, InstrumentSortOption sort, AudioEquipmentFilterConditions filterConditions
 	);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.ajou.hertz.domain.instrument.repository;
 import org.springframework.data.domain.Page;
 
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
@@ -19,7 +20,7 @@ public interface InstrumentRepositoryCustom {
 	);
 
 	Page<BassGuitar> findBassGuitars(
-		int page, int pageSize, InstrumentSortOption sort, InstrumentFilterConditions filterConditions
+		int page, int pageSize, InstrumentSortOption sort, BassGuitarFilterConditions filterConditions
 	);
 
 	Page<AcousticAndClassicGuitar> findAcousticAndClassicGuitars(

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
@@ -11,28 +11,13 @@ import static com.ajou.hertz.domain.user.entity.QUser.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 
-import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarBrand;
-import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarModel;
-import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarPickUp;
-import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
-import com.ajou.hertz.domain.instrument.constant.AmplifierBrand;
-import com.ajou.hertz.domain.instrument.constant.AmplifierType;
-import com.ajou.hertz.domain.instrument.constant.AmplifierUsage;
-import com.ajou.hertz.domain.instrument.constant.AudioEquipmentType;
-import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
-import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
-import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
-import com.ajou.hertz.domain.instrument.constant.EffectorFeature;
-import com.ajou.hertz.domain.instrument.constant.EffectorType;
-import com.ajou.hertz.domain.instrument.constant.ElectricGuitarBrand;
-import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
-import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
@@ -41,6 +26,7 @@ import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditio
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
@@ -48,6 +34,7 @@ import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.user.entity.User;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
@@ -68,188 +55,96 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 
 	@Override
 	public Page<ElectricGuitar> findElectricGuitars(
-		int page,
-		int pageSize,
-		InstrumentSortOption sort,
+		int page, int pageSize, InstrumentSortOption sort,
 		ElectricGuitarFilterConditions filterConditions
 	) {
-		PageRequest pageable = PageRequest.of(page, pageSize, sort.toSort());
-
-		List<Predicate> conditions =
-			new ArrayList<>(convertElectricGuitarFilterConditionsToPredicates(filterConditions));
-
-		List<ElectricGuitar> content = queryFactory
-			.selectFrom(electricGuitar)
-			.join(electricGuitar.seller, user).fetchJoin()
-			.where(conditions.toArray(Predicate[]::new))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.orderBy(convertSortToOrderSpecifiers(pageable.getSort(), createPathBuilder(electricGuitar)))
-			.fetch();
-
-		long totalCount = Optional.ofNullable(
-			queryFactory.select(electricGuitar.count())
-				.from(electricGuitar)
-				.join(electricGuitar.seller, user)
-				.where(conditions.toArray(Predicate[]::new))
-				.fetchOne()
-		).orElse(0L);
-
-		return new PageImpl<>(content, pageable, totalCount);
+		return findInstruments(
+			page, pageSize, sort, filterConditions, electricGuitar, electricGuitar.seller,
+			this::mapInstrumentFilterConditionsToPredicates
+		);
 	}
 
 	@Override
 	public Page<BassGuitar> findBassGuitars(
-		int page,
-		int pageSize,
-		InstrumentSortOption sort,
+		int page, int pageSize, InstrumentSortOption sort,
 		BassGuitarFilterConditions filterConditions
 	) {
-		PageRequest pageable = PageRequest.of(page, pageSize, sort.toSort());
-
-		List<Predicate> conditions =
-			new ArrayList<>(convertBassGuitarFilterConditionsToPredicates(filterConditions));
-
-		List<BassGuitar> content = queryFactory
-			.selectFrom(bassGuitar)
-			.join(bassGuitar.seller, user).fetchJoin()
-			.where(conditions.toArray(Predicate[]::new))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.orderBy(convertSortToOrderSpecifiers(pageable.getSort(), createPathBuilder(bassGuitar)))
-			.fetch();
-
-		long totalCount = Optional.ofNullable(
-			queryFactory.select(bassGuitar.count())
-				.from(bassGuitar)
-				.join(bassGuitar.seller, user)
-				.where(conditions.toArray(Predicate[]::new))
-				.fetchOne()
-		).orElse(0L);
-
-		return new PageImpl<>(content, pageable, totalCount);
+		return findInstruments(
+			page, pageSize, sort, filterConditions, bassGuitar, bassGuitar.seller,
+			this::mapInstrumentFilterConditionsToPredicates
+		);
 	}
 
 	@Override
 	public Page<AcousticAndClassicGuitar> findAcousticAndClassicGuitars(
-		int page,
-		int pageSize,
-		InstrumentSortOption sort,
+		int page, int pageSize, InstrumentSortOption sort,
 		AcousticAndClassicGuitarFilterConditions filterConditions
 	) {
-		PageRequest pageable = PageRequest.of(page, pageSize, sort.toSort());
-
-		List<Predicate> conditions =
-			new ArrayList<>(convertAcousticAndClassicGuitarFilterConditionsToPredicates(filterConditions));
-
-		List<AcousticAndClassicGuitar> content = queryFactory
-			.selectFrom(acousticAndClassicGuitar)
-			.join(acousticAndClassicGuitar.seller, user).fetchJoin()
-			.where(conditions.toArray(Predicate[]::new))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.orderBy(convertSortToOrderSpecifiers(pageable.getSort(), createPathBuilder(acousticAndClassicGuitar)))
-			.fetch();
-
-		long totalCount = Optional.ofNullable(
-			queryFactory.select(acousticAndClassicGuitar.count())
-				.from(acousticAndClassicGuitar)
-				.join(acousticAndClassicGuitar.seller, user)
-				.where(conditions.toArray(Predicate[]::new))
-				.fetchOne()
-		).orElse(0L);
-
-		return new PageImpl<>(content, pageable, totalCount);
+		return findInstruments(
+			page, pageSize, sort, filterConditions, acousticAndClassicGuitar, acousticAndClassicGuitar.seller,
+			this::mapInstrumentFilterConditionsToPredicates
+		);
 	}
 
 	@Override
 	public Page<Effector> findEffectors(
-		int page,
-		int pageSize,
-		InstrumentSortOption sort,
+		int page, int pageSize, InstrumentSortOption sort,
 		EffectorFilterConditions filterConditions
 	) {
-		PageRequest pageable = PageRequest.of(page, pageSize, sort.toSort());
-
-		List<Predicate> conditions = new ArrayList<>(convertEffectorFilterConditionsToPredicates(filterConditions));
-
-		List<Effector> content = queryFactory
-			.selectFrom(effector)
-			.join(effector.seller, user).fetchJoin()
-			.where(conditions.toArray(Predicate[]::new))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.orderBy(convertSortToOrderSpecifiers(pageable.getSort(), createPathBuilder(effector)))
-			.fetch();
-
-		long totalCount = Optional.ofNullable(
-			queryFactory.select(effector.count())
-				.from(effector)
-				.join(effector.seller, user)
-				.where(conditions.toArray(Predicate[]::new))
-				.fetchOne()
-		).orElse(0L);
-
-		return new PageImpl<>(content, pageable, totalCount);
+		return findInstruments(
+			page, pageSize, sort, filterConditions, effector, effector.seller,
+			this::mapInstrumentFilterConditionsToPredicates
+		);
 	}
 
 	@Override
 	public Page<Amplifier> findAmplifiers(
-		int page,
-		int pageSize,
-		InstrumentSortOption sort,
+		int page, int pageSize, InstrumentSortOption sort,
 		AmplifierFilterConditions filterConditions
 	) {
-		PageRequest pageable = PageRequest.of(page, pageSize, sort.toSort());
-
-		List<Predicate> conditions = new ArrayList<>(convertAmplifierFilterConditionsToPredicates(filterConditions));
-
-		List<Amplifier> content = queryFactory
-			.selectFrom(amplifier)
-			.join(amplifier.seller, user).fetchJoin()
-			.where(conditions.toArray(Predicate[]::new))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.orderBy(convertSortToOrderSpecifiers(pageable.getSort(), createPathBuilder(amplifier)))
-			.fetch();
-
-		long totalCount = Optional.ofNullable(
-			queryFactory.select(amplifier.count())
-				.from(amplifier)
-				.join(amplifier.seller, user)
-				.where(conditions.toArray(Predicate[]::new))
-				.fetchOne()
-		).orElse(0L);
-
-		return new PageImpl<>(content, pageable, totalCount);
+		return findInstruments(
+			page, pageSize, sort, filterConditions, amplifier, amplifier.seller,
+			this::mapInstrumentFilterConditionsToPredicates
+		);
 	}
 
 	@Override
 	public Page<AudioEquipment> findAudioEquipments(
-		int page,
-		int pageSize,
-		InstrumentSortOption sort,
+		int page, int pageSize, InstrumentSortOption sort,
 		AudioEquipmentFilterConditions filterConditions
+	) {
+		return findInstruments(
+			page, pageSize, sort, filterConditions, audioEquipment, audioEquipment.seller,
+			this::mapInstrumentFilterConditionsToPredicates
+		);
+	}
+
+	private <T extends Instrument, F extends InstrumentFilterConditions> Page<T> findInstruments(
+		int page, int pageSize, InstrumentSortOption sort,
+		F filterConditions,
+		EntityPathBase<T> qInstrument,
+		EntityPathBase<User> qSeller,
+		Function<F, List<Predicate>> filterConverter
 	) {
 		PageRequest pageable = PageRequest.of(page, pageSize, sort.toSort());
 
-		List<Predicate> conditions =
-			new ArrayList<>(convertAudioEquipmentFilterConditionsToPredicates(filterConditions));
+		List<Predicate> conditions = new ArrayList<>(filterConverter.apply(filterConditions));
 
-		List<AudioEquipment> content = queryFactory
-			.selectFrom(audioEquipment)
-			.join(audioEquipment.seller, user).fetchJoin()
-			.where(conditions.toArray(Predicate[]::new))
+		List<T> content = queryFactory
+			.selectFrom(qInstrument)
+			.join(qSeller, user).fetchJoin()
+			.where(conditions.toArray(new Predicate[0]))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
-			.orderBy(convertSortToOrderSpecifiers(pageable.getSort(), createPathBuilder(audioEquipment)))
+			.orderBy(convertSortToOrderSpecifiers(pageable.getSort(), createPathBuilder(qInstrument)))
 			.fetch();
 
 		long totalCount = Optional.ofNullable(
-			queryFactory.select(audioEquipment.count())
-				.from(audioEquipment)
-				.join(audioEquipment.seller, user)
-				.where(conditions.toArray(Predicate[]::new))
+			queryFactory
+				.select(qInstrument.count())
+				.from(qInstrument)
+				.join(qSeller, user)
+				.where(conditions.toArray(new Predicate[0]))
 				.fetchOne()
 		).orElse(0L);
 
@@ -261,7 +156,8 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 	}
 
 	private <T extends Instrument> OrderSpecifier<?>[] convertSortToOrderSpecifiers(
-		Sort sort, PathBuilder<T> pathBuilder
+		Sort sort,
+		PathBuilder<T> pathBuilder
 	) {
 		return sort.stream()
 			.map(order -> new OrderSpecifier<>(
@@ -270,163 +166,97 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 			)).toArray(OrderSpecifier[]::new);
 	}
 
-	private List<Predicate> convertElectricGuitarFilterConditionsToPredicates(
-		ElectricGuitarFilterConditions filterConditions
+	private List<Predicate> mapInstrumentFilterConditionsToPredicates(
+		InstrumentFilterConditions filterConditions,
+		EnumPath<InstrumentProgressStatus> progressStatusEntityPath,
+		StringPath tradeAddressSidoExpression,
+		StringPath tradeAddressSggExpression
 	) {
 		List<Predicate> res = new ArrayList<>();
-		res.add(applyProgressStatusCondition(filterConditions.getProgress(), electricGuitar.progressStatus));
-		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), electricGuitar.tradeAddress.sido));
-		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), electricGuitar.tradeAddress.sgg));
-		res.add(applyElectricGuitarBrandCondition(filterConditions.getBrand()));
-		res.add(applyElectricGuitarModelCondition(filterConditions.getModel()));
-		res.add(applyGuitarColorCondition(filterConditions.getColor(), electricGuitar.color));
+		res.add(createEqualCondition(filterConditions.getProgress(), progressStatusEntityPath));
+		res.add(createEqualCondition(filterConditions.getSido(), tradeAddressSidoExpression));
+		res.add(createEqualCondition(filterConditions.getSgg(), tradeAddressSggExpression));
 		return res;
 	}
 
-	private List<Predicate> convertBassGuitarFilterConditionsToPredicates(
-		BassGuitarFilterConditions filterConditions
-	) {
-		List<Predicate> res = new ArrayList<>();
-		res.add(applyProgressStatusCondition(filterConditions.getProgress(), bassGuitar.progressStatus));
-		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), bassGuitar.tradeAddress.sido));
-		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), bassGuitar.tradeAddress.sgg));
-		res.add(applyBassGuitarBrandCondition(filterConditions.getBrand()));
-		res.add(applyBassGuitarPickUpCondition(filterConditions.getPickUp()));
-		res.add(applyBassGuitarPreAmplifier(filterConditions.getPreAmplifier()));
-		res.add(applyGuitarColorCondition(filterConditions.getColor(), bassGuitar.color));
+	private List<Predicate> mapInstrumentFilterConditionsToPredicates(ElectricGuitarFilterConditions filterConditions) {
+		List<Predicate> res = mapInstrumentFilterConditionsToPredicates(
+			filterConditions,
+			electricGuitar.progressStatus,
+			electricGuitar.tradeAddress.sido,
+			electricGuitar.tradeAddress.sgg
+		);
+		res.add(createEqualCondition(filterConditions.getBrand(), electricGuitar.brand));
+		res.add(createEqualCondition(filterConditions.getModel(), electricGuitar.model));
+		res.add(createEqualCondition(filterConditions.getColor(), electricGuitar.color));
 		return res;
 	}
 
-	private List<Predicate> convertAcousticAndClassicGuitarFilterConditionsToPredicates(
-		AcousticAndClassicGuitarFilterConditions filterConditions
-	) {
-		List<Predicate> res = new ArrayList<>();
-		res.add(applyProgressStatusCondition(filterConditions.getProgress(), acousticAndClassicGuitar.progressStatus));
-		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), acousticAndClassicGuitar.tradeAddress.sido));
-		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), acousticAndClassicGuitar.tradeAddress.sgg));
-		res.add(applyAcousticAndClassicGuitarBrandCondition(filterConditions.getBrand()));
-		res.add(applyAcousticAndClassicGuitarModelCondition(filterConditions.getModel()));
-		res.add(applyAcousticAndClassicGuitarWood(filterConditions.getWood()));
-		res.add(applyAcousticAndClassicGuitarPickUpCondition(filterConditions.getPickUp()));
+	private List<Predicate> mapInstrumentFilterConditionsToPredicates(BassGuitarFilterConditions filterConditions) {
+		List<Predicate> res = mapInstrumentFilterConditionsToPredicates(
+			filterConditions,
+			bassGuitar.progressStatus,
+			bassGuitar.tradeAddress.sido,
+			bassGuitar.tradeAddress.sgg
+		);
+		res.add(createEqualCondition(filterConditions.getBrand(), bassGuitar.brand));
+		res.add(createEqualCondition(filterConditions.getPickUp(), bassGuitar.pickUp));
+		res.add(createEqualCondition(filterConditions.getPreAmplifier(), bassGuitar.preAmplifier));
+		res.add(createEqualCondition(filterConditions.getColor(), bassGuitar.color));
 		return res;
 	}
 
-	private List<Predicate> convertEffectorFilterConditionsToPredicates(
-		EffectorFilterConditions filterConditions
-	) {
-		List<Predicate> res = new ArrayList<>();
-		res.add(applyProgressStatusCondition(filterConditions.getProgress(), effector.progressStatus));
-		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), effector.tradeAddress.sido));
-		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), effector.tradeAddress.sgg));
-		res.add(applyEffectorTypeCondition(filterConditions.getType()));
-		res.add(applyEffectorFeatureCondition(filterConditions.getFeature()));
+	private List<Predicate> mapInstrumentFilterConditionsToPredicates(AcousticAndClassicGuitarFilterConditions filterConditions) {
+		List<Predicate> res = mapInstrumentFilterConditionsToPredicates(
+			filterConditions,
+			acousticAndClassicGuitar.progressStatus,
+			acousticAndClassicGuitar.tradeAddress.sido,
+			acousticAndClassicGuitar.tradeAddress.sgg
+		);
+		res.add(createEqualCondition(filterConditions.getBrand(), acousticAndClassicGuitar.brand));
+		res.add(createEqualCondition(filterConditions.getModel(), acousticAndClassicGuitar.model));
+		res.add(createEqualCondition(filterConditions.getWood(), acousticAndClassicGuitar.wood));
+		res.add(createEqualCondition(filterConditions.getPickUp(), acousticAndClassicGuitar.pickUp));
 		return res;
 	}
 
-	private List<Predicate> convertAmplifierFilterConditionsToPredicates(
-		AmplifierFilterConditions filterConditions
-	) {
-		List<Predicate> res = new ArrayList<>();
-		res.add(applyProgressStatusCondition(filterConditions.getProgress(), amplifier.progressStatus));
-		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), amplifier.tradeAddress.sido));
-		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), amplifier.tradeAddress.sgg));
-		res.add(applyAmplifierTypeCondition(filterConditions.getType()));
-		res.add(applyAmplifierBrandCondition(filterConditions.getBrand()));
-		res.add(applyAmplifierUsageCondition(filterConditions.getUsage()));
+	private List<Predicate> mapInstrumentFilterConditionsToPredicates(EffectorFilterConditions filterConditions) {
+		List<Predicate> res = mapInstrumentFilterConditionsToPredicates(
+			filterConditions,
+			effector.progressStatus,
+			effector.tradeAddress.sido,
+			effector.tradeAddress.sgg
+		);
+		res.add(createEqualCondition(filterConditions.getType(), effector.type));
+		res.add(createEqualCondition(filterConditions.getFeature(), effector.feature));
 		return res;
 	}
 
-	private List<Predicate> convertAudioEquipmentFilterConditionsToPredicates(
-		AudioEquipmentFilterConditions filterConditions
-	) {
-		List<Predicate> res = new ArrayList<>();
-		res.add(applyProgressStatusCondition(filterConditions.getProgress(), audioEquipment.progressStatus));
-		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), audioEquipment.tradeAddress.sido));
-		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), audioEquipment.tradeAddress.sgg));
-		res.add(applyAudioEquipmentTypeCondition(filterConditions.getType()));
+	private List<Predicate> mapInstrumentFilterConditionsToPredicates(AmplifierFilterConditions filterConditions) {
+		List<Predicate> res = mapInstrumentFilterConditionsToPredicates(
+			filterConditions,
+			amplifier.progressStatus,
+			amplifier.tradeAddress.sido,
+			amplifier.tradeAddress.sgg
+		);
+		res.add(createEqualCondition(filterConditions.getType(), amplifier.type));
+		res.add(createEqualCondition(filterConditions.getBrand(), amplifier.brand));
+		res.add(createEqualCondition(filterConditions.getUsage(), amplifier.usage));
 		return res;
 	}
 
-	private BooleanExpression applyProgressStatusCondition(
-		InstrumentProgressStatus progressStatus,
-		EnumPath<InstrumentProgressStatus> progressStatusExpression
-	) {
-		return createCondition(progressStatus, progressStatusExpression);
+	private List<Predicate> mapInstrumentFilterConditionsToPredicates(AudioEquipmentFilterConditions filterConditions) {
+		List<Predicate> res = mapInstrumentFilterConditionsToPredicates(
+			filterConditions,
+			audioEquipment.progressStatus,
+			audioEquipment.tradeAddress.sido,
+			audioEquipment.tradeAddress.sgg
+		);
+		res.add(createEqualCondition(filterConditions.getType(), audioEquipment.type));
+		return res;
 	}
 
-	private BooleanExpression applyTradeAddressSidoCondition(String sido, StringPath tradeAddressSidoExpression) {
-		return createCondition(sido, tradeAddressSidoExpression);
-	}
-
-	private BooleanExpression applyTradeAddressSggCondition(String sgg, StringPath tradeAddressSggExpression) {
-		return createCondition(sgg, tradeAddressSggExpression);
-	}
-
-	private BooleanExpression applyElectricGuitarBrandCondition(ElectricGuitarBrand brand) {
-		return createCondition(brand, electricGuitar.brand);
-	}
-
-	private BooleanExpression applyElectricGuitarModelCondition(ElectricGuitarModel model) {
-		return createCondition(model, electricGuitar.model);
-	}
-
-	private BooleanExpression applyBassGuitarBrandCondition(BassGuitarBrand brand) {
-		return createCondition(brand, bassGuitar.brand);
-	}
-
-	private BooleanExpression applyBassGuitarPickUpCondition(BassGuitarPickUp pickUp) {
-		return createCondition(pickUp, bassGuitar.pickUp);
-	}
-
-	private BooleanExpression applyBassGuitarPreAmplifier(BassGuitarPreAmplifier preAmplifier) {
-		return createCondition(preAmplifier, bassGuitar.preAmplifier);
-	}
-
-	private BooleanExpression applyGuitarColorCondition(GuitarColor color, EnumPath<GuitarColor> colorExpression) {
-		return createCondition(color, colorExpression);
-	}
-
-	private BooleanExpression applyAcousticAndClassicGuitarBrandCondition(AcousticAndClassicGuitarBrand brand) {
-		return createCondition(brand, acousticAndClassicGuitar.brand);
-	}
-
-	private BooleanExpression applyAcousticAndClassicGuitarModelCondition(AcousticAndClassicGuitarModel model) {
-		return createCondition(model, acousticAndClassicGuitar.model);
-	}
-
-	private BooleanExpression applyAcousticAndClassicGuitarWood(AcousticAndClassicGuitarWood wood) {
-		return createCondition(wood, acousticAndClassicGuitar.wood);
-	}
-
-	private BooleanExpression applyAcousticAndClassicGuitarPickUpCondition(AcousticAndClassicGuitarPickUp pickUp) {
-		return createCondition(pickUp, acousticAndClassicGuitar.pickUp);
-	}
-
-	private BooleanExpression applyEffectorTypeCondition(EffectorType type) {
-		return createCondition(type, effector.type);
-	}
-
-	private BooleanExpression applyEffectorFeatureCondition(EffectorFeature feature) {
-		return createCondition(feature, effector.feature);
-	}
-
-	private BooleanExpression applyAmplifierTypeCondition(AmplifierType type) {
-		return createCondition(type, amplifier.type);
-	}
-
-	private BooleanExpression applyAmplifierBrandCondition(AmplifierBrand brand) {
-		return createCondition(brand, amplifier.brand);
-	}
-
-	private BooleanExpression applyAmplifierUsageCondition(AmplifierUsage usage) {
-		return createCondition(usage, amplifier.usage);
-	}
-
-	private BooleanExpression applyAudioEquipmentTypeCondition(AudioEquipmentType type) {
-		return createCondition(type, audioEquipment.type);
-	}
-
-	private <T extends Comparable<T>> BooleanExpression createCondition(T value, ComparableExpression<T> path) {
+	private <T extends Comparable<T>> BooleanExpression createEqualCondition(T value, ComparableExpression<T> path) {
 		return value != null ? path.eq(value) : null;
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentRepositoryCustomImpl.java
@@ -2,10 +2,10 @@ package com.ajou.hertz.domain.instrument.repository;
 
 import static com.ajou.hertz.domain.instrument.entity.QAcousticAndClassicGuitar.*;
 import static com.ajou.hertz.domain.instrument.entity.QAmplifier.*;
+import static com.ajou.hertz.domain.instrument.entity.QAudioEquipment.*;
 import static com.ajou.hertz.domain.instrument.entity.QBassGuitar.*;
 import static com.ajou.hertz.domain.instrument.entity.QEffector.*;
 import static com.ajou.hertz.domain.instrument.entity.QElectricGuitar.*;
-import static com.ajou.hertz.domain.instrument.entity.QInstrument.*;
 import static com.ajou.hertz.domain.user.entity.QUser.*;
 
 import java.util.ArrayList;
@@ -24,6 +24,7 @@ import com.ajou.hertz.domain.instrument.constant.AcousticAndClassicGuitarWood;
 import com.ajou.hertz.domain.instrument.constant.AmplifierBrand;
 import com.ajou.hertz.domain.instrument.constant.AmplifierType;
 import com.ajou.hertz.domain.instrument.constant.AmplifierUsage;
+import com.ajou.hertz.domain.instrument.constant.AudioEquipmentType;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
 import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
@@ -36,10 +37,10 @@ import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
-import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
@@ -228,39 +229,26 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
-		InstrumentFilterConditions filterConditions
-	) {
-		return findInstrumentsByClassType(AudioEquipment.class, page, pageSize, sort, filterConditions);
-	}
-
-	private <T extends Instrument> Page<T> findInstrumentsByClassType(
-		Class<T> classType,
-		int page,
-		int pageSize,
-		InstrumentSortOption sort,
-		InstrumentFilterConditions filterConditions
+		AudioEquipmentFilterConditions filterConditions
 	) {
 		PageRequest pageable = PageRequest.of(page, pageSize, sort.toSort());
 
-		List<Predicate> conditions = new ArrayList<>();
-		conditions.add(instrument.instanceOf(classType));
+		List<Predicate> conditions =
+			new ArrayList<>(convertAudioEquipmentFilterConditionsToPredicates(filterConditions));
 
-		List<T> content = queryFactory
-			.selectFrom(instrument)
-			.join(instrument.seller, user).fetchJoin()
+		List<AudioEquipment> content = queryFactory
+			.selectFrom(audioEquipment)
+			.join(audioEquipment.seller, user).fetchJoin()
 			.where(conditions.toArray(Predicate[]::new))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())
-			.orderBy(convertSortToOrderSpecifiers(pageable.getSort(), createPathBuilder(instrument)))
-			.fetch()
-			.stream()
-			.map(classType::cast)
-			.toList();
+			.orderBy(convertSortToOrderSpecifiers(pageable.getSort(), createPathBuilder(audioEquipment)))
+			.fetch();
 
 		long totalCount = Optional.ofNullable(
-			queryFactory.select(instrument.count())
-				.from(instrument)
-				.join(instrument.seller, user)
+			queryFactory.select(audioEquipment.count())
+				.from(audioEquipment)
+				.join(audioEquipment.seller, user)
 				.where(conditions.toArray(Predicate[]::new))
 				.fetchOne()
 		).orElse(0L);
@@ -313,9 +301,9 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 		AcousticAndClassicGuitarFilterConditions filterConditions
 	) {
 		List<Predicate> res = new ArrayList<>();
-		res.add(applyProgressStatusCondition(filterConditions.getProgress(), bassGuitar.progressStatus));
-		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), bassGuitar.tradeAddress.sido));
-		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), bassGuitar.tradeAddress.sgg));
+		res.add(applyProgressStatusCondition(filterConditions.getProgress(), acousticAndClassicGuitar.progressStatus));
+		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), acousticAndClassicGuitar.tradeAddress.sido));
+		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), acousticAndClassicGuitar.tradeAddress.sgg));
 		res.add(applyAcousticAndClassicGuitarBrandCondition(filterConditions.getBrand()));
 		res.add(applyAcousticAndClassicGuitarModelCondition(filterConditions.getModel()));
 		res.add(applyAcousticAndClassicGuitarWood(filterConditions.getWood()));
@@ -327,9 +315,9 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 		EffectorFilterConditions filterConditions
 	) {
 		List<Predicate> res = new ArrayList<>();
-		res.add(applyProgressStatusCondition(filterConditions.getProgress(), bassGuitar.progressStatus));
-		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), bassGuitar.tradeAddress.sido));
-		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), bassGuitar.tradeAddress.sgg));
+		res.add(applyProgressStatusCondition(filterConditions.getProgress(), effector.progressStatus));
+		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), effector.tradeAddress.sido));
+		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), effector.tradeAddress.sgg));
 		res.add(applyEffectorTypeCondition(filterConditions.getType()));
 		res.add(applyEffectorFeatureCondition(filterConditions.getFeature()));
 		return res;
@@ -339,12 +327,23 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 		AmplifierFilterConditions filterConditions
 	) {
 		List<Predicate> res = new ArrayList<>();
-		res.add(applyProgressStatusCondition(filterConditions.getProgress(), bassGuitar.progressStatus));
-		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), bassGuitar.tradeAddress.sido));
-		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), bassGuitar.tradeAddress.sgg));
+		res.add(applyProgressStatusCondition(filterConditions.getProgress(), amplifier.progressStatus));
+		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), amplifier.tradeAddress.sido));
+		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), amplifier.tradeAddress.sgg));
 		res.add(applyAmplifierTypeCondition(filterConditions.getType()));
 		res.add(applyAmplifierBrandCondition(filterConditions.getBrand()));
 		res.add(applyAmplifierUsageCondition(filterConditions.getUsage()));
+		return res;
+	}
+
+	private List<Predicate> convertAudioEquipmentFilterConditionsToPredicates(
+		AudioEquipmentFilterConditions filterConditions
+	) {
+		List<Predicate> res = new ArrayList<>();
+		res.add(applyProgressStatusCondition(filterConditions.getProgress(), audioEquipment.progressStatus));
+		res.add(applyTradeAddressSidoCondition(filterConditions.getSido(), audioEquipment.tradeAddress.sido));
+		res.add(applyTradeAddressSggCondition(filterConditions.getSgg(), audioEquipment.tradeAddress.sgg));
+		res.add(applyAudioEquipmentTypeCondition(filterConditions.getType()));
 		return res;
 	}
 
@@ -421,6 +420,10 @@ public class InstrumentRepositoryCustomImpl implements InstrumentRepositoryCusto
 
 	private BooleanExpression applyAmplifierUsageCondition(AmplifierUsage usage) {
 		return createCondition(usage, amplifier.usage);
+	}
+
+	private BooleanExpression applyAudioEquipmentTypeCondition(AudioEquipmentType type) {
+		return createCondition(type, audioEquipment.type);
 	}
 
 	private <T extends Comparable<T>> BooleanExpression createCondition(T value, ComparableExpression<T> path) {

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -15,10 +15,10 @@ import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
-import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -95,7 +95,7 @@ public class InstrumentQueryService {
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
-		InstrumentFilterConditions filterConditions
+		AudioEquipmentFilterConditions filterConditions
 	) {
 		return instrumentRepository
 			.findAudioEquipments(page, pageSize, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -13,6 +13,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
@@ -47,7 +48,7 @@ public class InstrumentQueryService {
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
-		InstrumentFilterConditions filterConditions
+		BassGuitarFilterConditions filterConditions
 	) {
 		return instrumentRepository
 			.findBassGuitars(page, pageSize, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -13,6 +13,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
@@ -59,7 +60,7 @@ public class InstrumentQueryService {
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
-		InstrumentFilterConditions filterConditions
+		AcousticAndClassicGuitarFilterConditions filterConditions
 	) {
 		return instrumentRepository
 			.findAcousticAndClassicGuitars(page, pageSize, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -14,6 +14,7 @@ import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
@@ -83,7 +84,7 @@ public class InstrumentQueryService {
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
-		InstrumentFilterConditions filterConditions
+		AmplifierFilterConditions filterConditions
 	) {
 		return instrumentRepository
 			.findAmplifiers(page, pageSize, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -13,6 +13,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
 
@@ -35,7 +36,7 @@ public class InstrumentQueryService {
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
-		InstrumentFilterConditions filterConditions
+		ElectricGuitarFilterConditions filterConditions
 	) {
 		return instrumentRepository
 			.findElectricGuitars(page, pageSize, sort, filterConditions)

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -15,6 +15,7 @@ import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
@@ -71,7 +72,7 @@ public class InstrumentQueryService {
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
-		InstrumentFilterConditions filterConditions
+		EffectorFilterConditions filterConditions
 	) {
 		return instrumentRepository
 			.findEffectors(page, pageSize, sort, filterConditions)

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
@@ -35,6 +35,7 @@ import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
@@ -74,7 +75,7 @@ class InstrumentRepositoryTest {
 	void 일렉_기타_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
-		ElectricGuitarFilterConditions filterConditions = createElectricGuitarFilterConditions();
+		ElectricGuitarFilterConditions filterConditions = createEmptyElectricGuitarFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createBassGuitar(user),
@@ -112,7 +113,8 @@ class InstrumentRepositoryTest {
 	void 어쿠스틱_클래식_기타_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
-		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
+		AcousticAndClassicGuitarFilterConditions filterConditions =
+			createEmptyAcousticAndClassicGuitarFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -121,9 +123,7 @@ class InstrumentRepositoryTest {
 		));
 
 		// when
-		Page<AcousticAndClassicGuitar> result = sut.findAcousticAndClassicGuitars(
-			0, 10, sortOption, filterConditions
-		);
+		Page<AcousticAndClassicGuitar> result = sut.findAcousticAndClassicGuitars(0, 10, sortOption, filterConditions);
 
 		// then
 		assertThat(result.getNumberOfElements()).isEqualTo(savedInstruments.size() - 1);
@@ -311,18 +311,16 @@ class InstrumentRepositoryTest {
 		return ReflectionUtils.createInstrumentFilterConditions(null, null, null);
 	}
 
-	private ElectricGuitarFilterConditions createElectricGuitarFilterConditions() throws Exception {
-		return ReflectionUtils.createElectricGuitarFilterConditions(
-			InstrumentProgressStatus.SELLING,
-			"서울특별시",
-			null,
-			ElectricGuitarBrand.FENDER_USA,
-			ElectricGuitarModel.TELECASTER,
-			GuitarColor.RED
-		);
+	private ElectricGuitarFilterConditions createEmptyElectricGuitarFilterConditions() throws Exception {
+		return ReflectionUtils.createElectricGuitarFilterConditions(null, null, null, null, null, null);
 	}
 
 	private BassGuitarFilterConditions createEmptyBassGuitarFilterConditions() throws Exception {
 		return ReflectionUtils.createBassGuitarFilterConditions(null, null, null, null, null, null, null);
+	}
+
+	private AcousticAndClassicGuitarFilterConditions createEmptyAcousticAndClassicGuitarFilterConditions(
+	) throws Exception {
+		return ReflectionUtils.createAcousticAndClassicGuitarFilterConditions(null, null, null, null, null, null, null);
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
@@ -36,6 +36,7 @@ import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
@@ -72,8 +73,7 @@ class InstrumentRepositoryTest {
 	void 일렉_기타_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
-		InstrumentFilterConditions filterConditions =
-			createInstrumentFilterConditions(InstrumentProgressStatus.SELLING);
+		ElectricGuitarFilterConditions filterConditions = createElectricGuitarFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createBassGuitar(user),
@@ -356,11 +356,19 @@ class InstrumentRepositoryTest {
 		return instrumentFilterConditionsConstructor.newInstance();
 	}
 
-	private InstrumentFilterConditions createInstrumentFilterConditions(InstrumentProgressStatus progressStatus) throws
-		Exception {
-		Constructor<InstrumentFilterConditions> instrumentFilterConditionsConstructor =
-			InstrumentFilterConditions.class.getDeclaredConstructor(InstrumentProgressStatus.class);
-		instrumentFilterConditionsConstructor.setAccessible(true);
-		return instrumentFilterConditionsConstructor.newInstance(progressStatus);
+	private ElectricGuitarFilterConditions createElectricGuitarFilterConditions() throws Exception {
+		Constructor<ElectricGuitarFilterConditions> constructor = ElectricGuitarFilterConditions.class.getDeclaredConstructor(
+			InstrumentProgressStatus.class, String.class, String.class,
+			ElectricGuitarBrand.class, ElectricGuitarModel.class, GuitarColor.class
+		);
+		constructor.setAccessible(true);
+		return constructor.newInstance(
+			InstrumentProgressStatus.SELLING,
+			"서울특별시",
+			null,
+			ElectricGuitarBrand.FENDER_USA,
+			ElectricGuitarModel.TELECASTER,
+			GuitarColor.RED
+		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
@@ -93,6 +93,42 @@ class InstrumentRepositoryTest {
 	}
 
 	@Test
+	void 필터링_조건이_주어지고_일렉_기타_목록을_조회하면_조건에_일치하는_매물이_조회된다() throws Exception {
+		// given
+		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
+		ElectricGuitarFilterConditions filterConditions = createElectricGuitarFilterConditions(
+			InstrumentProgressStatus.SELLING,
+			ElectricGuitarBrand.FENDER_USA,
+			ElectricGuitarModel.TELECASTER,
+			GuitarColor.RED
+		);
+		User user = userRepository.save(createUser());
+		sut.saveAll(List.of(
+			createBassGuitar(user),
+			createElectricGuitar(
+				user,
+				InstrumentProgressStatus.SELLING,
+				ElectricGuitarBrand.FENDER_JAPAN,
+				ElectricGuitarModel.TELECASTER,
+				GuitarColor.BLACK
+			),
+			createElectricGuitar(
+				user,
+				InstrumentProgressStatus.SELLING,
+				ElectricGuitarBrand.FENDER_USA,
+				ElectricGuitarModel.TELECASTER,
+				GuitarColor.RED
+			)
+		));
+
+		// when
+		Page<ElectricGuitar> result = sut.findElectricGuitars(0, 10, sortOption, filterConditions);
+
+		// then
+		assertThat(result.getNumberOfElements()).isEqualTo(1);
+	}
+
+	@Test
 	void 베이스_기타_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
@@ -207,6 +243,30 @@ class InstrumentRepositoryTest {
 		);
 	}
 
+	private ElectricGuitar createElectricGuitar(
+		User seller,
+		InstrumentProgressStatus progressStatus,
+		ElectricGuitarBrand brand,
+		ElectricGuitarModel model,
+		GuitarColor color
+	) throws Exception {
+		return ReflectionUtils.createElectricGuitar(
+			null,
+			seller,
+			"Test electric guitar",
+			progressStatus,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			brand,
+			model,
+			(short)2014,
+			color
+		);
+	}
+
 	private ElectricGuitar createElectricGuitar(User seller) throws Exception {
 		return ReflectionUtils.createElectricGuitar(
 			null,
@@ -311,6 +371,15 @@ class InstrumentRepositoryTest {
 
 	private ElectricGuitarFilterConditions createEmptyElectricGuitarFilterConditions() throws Exception {
 		return ReflectionUtils.createElectricGuitarFilterConditions(null, null, null, null, null, null);
+	}
+
+	private ElectricGuitarFilterConditions createElectricGuitarFilterConditions(
+		InstrumentProgressStatus progressStatus,
+		ElectricGuitarBrand brand,
+		ElectricGuitarModel model,
+		GuitarColor color
+	) throws Exception {
+		return ReflectionUtils.createElectricGuitarFilterConditions(progressStatus, null, null, brand, model, color);
 	}
 
 	private BassGuitarFilterConditions createEmptyBassGuitarFilterConditions() throws Exception {

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
@@ -37,10 +37,10 @@ import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
-import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
@@ -173,7 +173,7 @@ class InstrumentRepositoryTest {
 	void 음향_장비_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_ASC;
-		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
+		AudioEquipmentFilterConditions filterConditions = createAudioEquipmentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -309,10 +309,6 @@ class InstrumentRepositoryTest {
 		);
 	}
 
-	private InstrumentFilterConditions createEmptyInstrumentFilterConditions() throws Exception {
-		return ReflectionUtils.createInstrumentFilterConditions(null, null, null);
-	}
-
 	private ElectricGuitarFilterConditions createEmptyElectricGuitarFilterConditions() throws Exception {
 		return ReflectionUtils.createElectricGuitarFilterConditions(null, null, null, null, null, null);
 	}
@@ -332,5 +328,9 @@ class InstrumentRepositoryTest {
 
 	private AmplifierFilterConditions createEmptyAmplifierFilterConditions() throws Exception {
 		return ReflectionUtils.createAmplifierFilterConditions(null, null, null, null, null, null);
+	}
+
+	private AudioEquipmentFilterConditions createAudioEquipmentFilterConditions() throws Exception {
+		return ReflectionUtils.createAudioEquipmentFilterConditions(null, null, null, null);
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
@@ -37,6 +37,7 @@ import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
@@ -133,7 +134,7 @@ class InstrumentRepositoryTest {
 	void 이펙터_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
-		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
+		EffectorFilterConditions filterConditions = createEmptyEffectorFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -322,5 +323,9 @@ class InstrumentRepositoryTest {
 	private AcousticAndClassicGuitarFilterConditions createEmptyAcousticAndClassicGuitarFilterConditions(
 	) throws Exception {
 		return ReflectionUtils.createAcousticAndClassicGuitarFilterConditions(null, null, null, null, null, null, null);
+	}
+
+	private EffectorFilterConditions createEmptyEffectorFilterConditions() throws Exception {
+		return ReflectionUtils.createEffectorFilterConditions(null, null, null, null, null);
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
@@ -36,6 +36,7 @@ import com.ajou.hertz.domain.instrument.constant.ElectricGuitarModel;
 import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
+import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
@@ -92,7 +93,7 @@ class InstrumentRepositoryTest {
 	void 베이스_기타_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
-		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
+		BassGuitarFilterConditions filterConditions = createEmptyBassGuitarFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -111,7 +112,7 @@ class InstrumentRepositoryTest {
 	void 어쿠스틱_클래식_기타_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
-		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
+		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -132,7 +133,7 @@ class InstrumentRepositoryTest {
 	void 이펙터_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
-		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
+		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -151,7 +152,7 @@ class InstrumentRepositoryTest {
 	void 앰프_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
-		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
+		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -170,7 +171,7 @@ class InstrumentRepositoryTest {
 	void 음향_장비_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_ASC;
-		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
+		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -349,7 +350,7 @@ class InstrumentRepositoryTest {
 		);
 	}
 
-	private InstrumentFilterConditions createInstrumentFilterConditions() throws Exception {
+	private InstrumentFilterConditions createEmptyInstrumentFilterConditions() throws Exception {
 		Constructor<InstrumentFilterConditions> instrumentFilterConditionsConstructor =
 			InstrumentFilterConditions.class.getDeclaredConstructor();
 		instrumentFilterConditionsConstructor.setAccessible(true);
@@ -370,5 +371,11 @@ class InstrumentRepositoryTest {
 			ElectricGuitarModel.TELECASTER,
 			GuitarColor.RED
 		);
+	}
+
+	private BassGuitarFilterConditions createEmptyBassGuitarFilterConditions() throws Exception {
+		Constructor<BassGuitarFilterConditions> constructor = BassGuitarFilterConditions.class.getDeclaredConstructor();
+		constructor.setAccessible(true);
+		return constructor.newInstance();
 	}
 }

--- a/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
+++ b/src/test/java/com/ajou/hertz/integration/domain/instrument/repository/InstrumentRepositoryTest.java
@@ -36,6 +36,7 @@ import com.ajou.hertz.domain.instrument.constant.GuitarColor;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
 import com.ajou.hertz.domain.instrument.constant.InstrumentSortOption;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
@@ -153,7 +154,7 @@ class InstrumentRepositoryTest {
 	void 앰프_목록을_조회한다() throws Exception {
 		// given
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
-		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
+		AmplifierFilterConditions filterConditions = createEmptyAmplifierFilterConditions();
 		User user = userRepository.save(createUser());
 		List<Instrument> savedInstruments = sut.saveAll(List.of(
 			createElectricGuitar(user),
@@ -327,5 +328,9 @@ class InstrumentRepositoryTest {
 
 	private EffectorFilterConditions createEmptyEffectorFilterConditions() throws Exception {
 		return ReflectionUtils.createEffectorFilterConditions(null, null, null, null, null);
+	}
+
+	private AmplifierFilterConditions createEmptyAmplifierFilterConditions() throws Exception {
+		return ReflectionUtils.createAmplifierFilterConditions(null, null, null, null, null, null);
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -95,7 +95,7 @@ class InstrumentControllerTest {
 	}
 
 	@Test
-	void 전체_악기_매물_목록을_조회한다() throws Exception {
+	void 종류_상관_없이_전체_악기_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;
 		int page = 0;
@@ -116,7 +116,9 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
-					.param("progress", filterConditions.getProgress().name())
+					.param("progress", InstrumentProgressStatus.SELLING.name())
+					.param("sido", "서울특별시")
+					.param("sgg", "종로구")
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
@@ -127,12 +129,11 @@ class InstrumentControllerTest {
 	}
 
 	@Test
-	void 일렉_기타_매물_목록을_조회한다() throws Exception {
+	void 필터링_조건이_주어지고_주어진_조건에_해당하는_일렉_기타_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;
 		int page = 0;
 		int pageSize = 10;
-		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
 		InstrumentSortOption sortOption = InstrumentSortOption.CREATED_BY_DESC;
 		Page<ElectricGuitarDto> expectedResult = new PageImpl<>(List.of(
 			createElectricGuitarDto(2L, userId),
@@ -150,7 +151,12 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
-					.param("progress", filterConditions.getProgress().name())
+					.param("progress", InstrumentProgressStatus.SELLING.name())
+					.param("sido", "서울특별시")
+					.param("sgg", "종로구")
+					.param("brand", ElectricGuitarBrand.FENDER_USA.name())
+					.param("model", ElectricGuitarModel.TELECASTER.name())
+					.param("color", GuitarColor.RED.name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
@@ -163,7 +169,7 @@ class InstrumentControllerTest {
 	}
 
 	@Test
-	void 베이스_기타_매물_목록을_조회한다() throws Exception {
+	void 필터링_조건이_주어지고_주어진_조건에_해당하는_베이스_기타_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;
 		int page = 0;
@@ -186,7 +192,13 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
-					.param("progress", filterConditions.getProgress().name())
+					.param("progress", InstrumentProgressStatus.SELLING.name())
+					.param("sido", "서울특별시")
+					.param("sgg", "종로구")
+					.param("brand", BassGuitarBrand.FENDER.name())
+					.param("pickUp", BassGuitarPickUp.ETC.name())
+					.param("preAmplifier", BassGuitarPreAmplifier.ACTIVE.name())
+					.param("color", GuitarColor.BLUE.name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
@@ -199,7 +211,7 @@ class InstrumentControllerTest {
 	}
 
 	@Test
-	void 어쿠스틱_클래식_기타_매물_목록을_조회한다() throws Exception {
+	void 필터링_조건이_주어지고_주어진_조건에_해당하는_어쿠스틱_클래식_기타_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;
 		int page = 0;
@@ -222,7 +234,13 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
-					.param("progress", filterConditions.getProgress().name())
+					.param("progress", InstrumentProgressStatus.SELLING.name())
+					.param("sido", "서울특별시")
+					.param("sgg", "종로구")
+					.param("brand", AcousticAndClassicGuitarBrand.CORT.name())
+					.param("model", AcousticAndClassicGuitarModel.JUMBO_BODY.name())
+					.param("wood", AcousticAndClassicGuitarWood.SOLID_WOOD.name())
+					.param("pickUp", AcousticAndClassicGuitarPickUp.MICROPHONE.name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
@@ -237,7 +255,7 @@ class InstrumentControllerTest {
 	}
 
 	@Test
-	void 이펙터_매물_목록을_조회한다() throws Exception {
+	void 필터링_조건이_주어지고_주어진_조건에_해당하는_이펙터_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;
 		int page = 0;
@@ -260,7 +278,11 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
-					.param("progress", filterConditions.getProgress().name())
+					.param("progress", InstrumentProgressStatus.SELLING.name())
+					.param("sido", "서울특별시")
+					.param("sgg", "종로구")
+					.param("type", EffectorType.GUITAR.name())
+					.param("feature", EffectorFeature.BASS_COMPRESSOR.name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
@@ -273,7 +295,7 @@ class InstrumentControllerTest {
 	}
 
 	@Test
-	void 앰프_매물_목록을_조회한다() throws Exception {
+	void 필터링_조건이_주어지고_주어진_조건에_해당하는_앰프_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;
 		int page = 0;
@@ -296,7 +318,12 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
-					.param("progress", filterConditions.getProgress().name())
+					.param("progress", InstrumentProgressStatus.SELLING.name())
+					.param("sido", "서울특별시")
+					.param("sgg", "종로구")
+					.param("type", AmplifierType.GUITAR.name())
+					.param("brand", AmplifierBrand.FENDER.name())
+					.param("usage", AmplifierUsage.HOME.name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))
@@ -309,7 +336,7 @@ class InstrumentControllerTest {
 	}
 
 	@Test
-	void 음향_장비_매물_목록을_조회한다() throws Exception {
+	void 필터링_조건이_주어지고_주어진_조건에_해당하는_음향_장비_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;
 		int page = 0;
@@ -332,7 +359,10 @@ class InstrumentControllerTest {
 					.param("page", String.valueOf(page))
 					.param("size", String.valueOf(pageSize))
 					.param("sort", sortOption.name())
-					.param("progress", filterConditions.getProgress().name())
+					.param("progress", InstrumentProgressStatus.SELLING.name())
+					.param("sido", "서울특별시")
+					.param("sgg", "종로구")
+					.param("type", AudioEquipmentType.AUDIO_EQUIPMENT.name())
 			)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.numberOfElements").value(expectedResult.getNumberOfElements()))

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -58,6 +58,7 @@ import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentImageDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
@@ -321,7 +322,7 @@ class InstrumentControllerTest {
 			createAudioEquipmentDto(4L, userId)
 		));
 		given(instrumentQueryService.findAudioEquipments(
-			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+			eq(page), eq(pageSize), eq(sortOption), any(AudioEquipmentFilterConditions.class)
 		)).willReturn(expectedResult);
 
 		// when & then
@@ -339,7 +340,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findAudioEquipments(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
+			.findAudioEquipments(eq(page), eq(pageSize), eq(sortOption), any(AudioEquipmentFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -63,6 +63,7 @@ import com.ajou.hertz.domain.instrument.dto.request.CreateNewAudioEquipmentReque
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewEffectorRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
+import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.service.InstrumentCommandService;
 import com.ajou.hertz.domain.instrument.service.InstrumentQueryService;
@@ -134,7 +135,7 @@ class InstrumentControllerTest {
 			createElectricGuitarDto(4L, userId)
 		));
 		given(instrumentQueryService.findElectricGuitars(
-			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+			eq(page), eq(pageSize), eq(sortOption), any(ElectricGuitarFilterConditions.class)
 		)).willReturn(expectedResult);
 
 		// when & then
@@ -152,7 +153,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findElectricGuitars(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
+			.findElectricGuitars(eq(page), eq(pageSize), eq(sortOption), any(ElectricGuitarFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -1000,11 +1001,14 @@ class InstrumentControllerTest {
 	}
 
 	private InstrumentFilterConditions createInstrumentFilterConditions() throws Exception {
-		Constructor<InstrumentFilterConditions> instrumentFilterConditionsConstructor =
-			InstrumentFilterConditions.class.getDeclaredConstructor(InstrumentProgressStatus.class);
-		instrumentFilterConditionsConstructor.setAccessible(true);
-		return instrumentFilterConditionsConstructor.newInstance(
-			InstrumentProgressStatus.SELLING
+		Constructor<InstrumentFilterConditions> constructor = InstrumentFilterConditions.class.getDeclaredConstructor(
+			InstrumentProgressStatus.class, String.class, String.class
+		);
+		constructor.setAccessible(true);
+		return constructor.newInstance(
+			InstrumentProgressStatus.SELLING,
+			"서울특별시",
+			"마포구"
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -57,6 +57,7 @@ import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentImageDto;
+import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAudioEquipmentRequest;
@@ -171,7 +172,7 @@ class InstrumentControllerTest {
 			createBassGuitarDto(4L, userId)
 		));
 		given(instrumentQueryService.findBassGuitars(
-			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+			eq(page), eq(pageSize), eq(sortOption), any(BassGuitarFilterConditions.class)
 		)).willReturn(expectedResult);
 
 		// when & then
@@ -189,7 +190,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findBassGuitars(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
+			.findBassGuitars(eq(page), eq(pageSize), eq(sortOption), any(BassGuitarFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -64,6 +64,7 @@ import com.ajou.hertz.domain.instrument.dto.request.CreateNewAudioEquipmentReque
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewEffectorRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
+import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.service.InstrumentCommandService;
@@ -247,7 +248,7 @@ class InstrumentControllerTest {
 			createEffectorDto(4L, userId)
 		));
 		given(instrumentQueryService.findEffectors(
-			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+			eq(page), eq(pageSize), eq(sortOption), any(EffectorFilterConditions.class)
 		)).willReturn(expectedResult);
 
 		// when & then
@@ -265,7 +266,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findEffectors(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
+			.findEffectors(eq(page), eq(pageSize), eq(sortOption), any(EffectorFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -56,6 +56,7 @@ import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentImageDto;
+import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
@@ -208,7 +209,7 @@ class InstrumentControllerTest {
 			createAcousticAndClassicGuitarDto(4L, userId)
 		));
 		given(instrumentQueryService.findAcousticAndClassicGuitars(
-			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+			eq(page), eq(pageSize), eq(sortOption), any(AcousticAndClassicGuitarFilterConditions.class)
 		)).willReturn(expectedResult);
 
 		// when & then
@@ -227,7 +228,7 @@ class InstrumentControllerTest {
 		then(instrumentQueryService)
 			.should()
 			.findAcousticAndClassicGuitars(
-				eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+				eq(page), eq(pageSize), eq(sortOption), any(AcousticAndClassicGuitarFilterConditions.class)
 			);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -57,6 +57,7 @@ import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentImageDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
@@ -284,7 +285,7 @@ class InstrumentControllerTest {
 			createAmplifierDto(4L, userId)
 		));
 		given(instrumentQueryService.findAmplifiers(
-			eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class)
+			eq(page), eq(pageSize), eq(sortOption), any(AmplifierFilterConditions.class)
 		)).willReturn(expectedResult);
 
 		// when & then
@@ -302,7 +303,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findAmplifiers(eq(page), eq(pageSize), eq(sortOption), any(InstrumentFilterConditions.class));
+			.findAmplifiers(eq(page), eq(pageSize), eq(sortOption), any(AmplifierFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -45,6 +45,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
@@ -101,7 +102,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
-		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
+		ElectricGuitarFilterConditions filterConditions = createElectricGuitarFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<ElectricGuitar> expectedResult = new PageImpl<>(List.of(
@@ -469,5 +470,21 @@ class InstrumentQueryServiceTest {
 			InstrumentFilterConditions.class.getDeclaredConstructor();
 		instrumentFilterConditionsConstructor.setAccessible(true);
 		return instrumentFilterConditionsConstructor.newInstance();
+	}
+
+	private ElectricGuitarFilterConditions createElectricGuitarFilterConditions() throws Exception {
+		Constructor<ElectricGuitarFilterConditions> constructor = ElectricGuitarFilterConditions.class.getDeclaredConstructor(
+			InstrumentProgressStatus.class, String.class, String.class,
+			ElectricGuitarBrand.class, ElectricGuitarModel.class, GuitarColor.class
+		);
+		constructor.setAccessible(true);
+		return constructor.newInstance(
+			InstrumentProgressStatus.SELLING,
+			"서울특별시",
+			"종로구",
+			ElectricGuitarBrand.FENDER_USA,
+			ElectricGuitarModel.TELECASTER,
+			GuitarColor.RED
+		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -45,6 +45,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
@@ -131,7 +132,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
-		InstrumentFilterConditions filterConditions = createInstrumentFilterConditions();
+		BassGuitarFilterConditions filterConditions = createBassGuitarFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<BassGuitar> expectedResult = new PageImpl<>(List.of(
@@ -484,6 +485,23 @@ class InstrumentQueryServiceTest {
 			"종로구",
 			ElectricGuitarBrand.FENDER_USA,
 			ElectricGuitarModel.TELECASTER,
+			GuitarColor.RED
+		);
+	}
+
+	private BassGuitarFilterConditions createBassGuitarFilterConditions() throws Exception {
+		Constructor<BassGuitarFilterConditions> constructor = BassGuitarFilterConditions.class.getDeclaredConstructor(
+			InstrumentProgressStatus.class, String.class, String.class,
+			BassGuitarBrand.class, BassGuitarPickUp.class, BassGuitarPreAmplifier.class, GuitarColor.class
+		);
+		constructor.setAccessible(true);
+		return constructor.newInstance(
+			InstrumentProgressStatus.SELLING,
+			"서울특별시",
+			"종로구",
+			BassGuitarBrand.FENDER,
+			BassGuitarPickUp.JAZZ,
+			BassGuitarPreAmplifier.ACTIVE,
 			GuitarColor.RED
 		);
 	}

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -46,6 +46,7 @@ import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
@@ -192,7 +193,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
-		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
+		EffectorFilterConditions filterConditions = createEmptyEffectorFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<Effector> expectedResult = new PageImpl<>(List.of(
@@ -456,6 +457,16 @@ class InstrumentQueryServiceTest {
 			AcousticAndClassicGuitarModel.DREADNOUGHT,
 			AcousticAndClassicGuitarWood.PLYWOOD_AND_SOLID_WOOD,
 			AcousticAndClassicGuitarPickUp.MAGNETIC
+		);
+	}
+
+	private EffectorFilterConditions createEmptyEffectorFilterConditions() throws Exception {
+		return ReflectionUtils.createEffectorFilterConditions(
+			InstrumentProgressStatus.SOLD_OUT,
+			"서울특별시",
+			"종로구",
+			EffectorType.GUITAR,
+			EffectorFeature.ETC
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -44,6 +44,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
@@ -160,7 +161,8 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
-		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
+		AcousticAndClassicGuitarFilterConditions filterConditions =
+			createEmptyAcousticAndClassicGuitarFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<AcousticAndClassicGuitar> expectedResult = new PageImpl<>(List.of(
@@ -441,6 +443,19 @@ class InstrumentQueryServiceTest {
 			BassGuitarPickUp.JAZZ,
 			BassGuitarPreAmplifier.ACTIVE,
 			GuitarColor.RED
+		);
+	}
+
+	private AcousticAndClassicGuitarFilterConditions createEmptyAcousticAndClassicGuitarFilterConditions(
+	) throws Exception {
+		return ReflectionUtils.createAcousticAndClassicGuitarFilterConditions(
+			InstrumentProgressStatus.RESERVED,
+			"서울특별시",
+			"종로구",
+			AcousticAndClassicGuitarBrand.BENTIVOGLIO,
+			AcousticAndClassicGuitarModel.DREADNOUGHT,
+			AcousticAndClassicGuitarWood.PLYWOOD_AND_SOLID_WOOD,
+			AcousticAndClassicGuitarPickUp.MAGNETIC
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -46,6 +46,7 @@ import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
@@ -250,7 +251,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
-		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
+		AudioEquipmentFilterConditions filterConditions = createAudioEquipmentFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<AudioEquipment> expectedResult = new PageImpl<>(List.of(
@@ -479,6 +480,15 @@ class InstrumentQueryServiceTest {
 			AmplifierType.GUITAR,
 			AmplifierBrand.FENDER,
 			AmplifierUsage.HOME
+		);
+	}
+
+	private AudioEquipmentFilterConditions createAudioEquipmentFilterConditions() throws Exception {
+		return ReflectionUtils.createAudioEquipmentFilterConditions(
+			InstrumentProgressStatus.SELLING,
+			"서울특별시",
+			"종로구",
+			AudioEquipmentType.AUDIO_EQUIPMENT
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -45,6 +45,7 @@ import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
@@ -221,7 +222,7 @@ class InstrumentQueryServiceTest {
 		// given
 		int page = 0;
 		int pageSize = 10;
-		InstrumentFilterConditions filterConditions = createEmptyInstrumentFilterConditions();
+		AmplifierFilterConditions filterConditions = createAmplifierFilterConditions();
 		InstrumentSortOption sort = InstrumentSortOption.CREATED_BY_DESC;
 		User user = createUser();
 		Page<Amplifier> expectedResult = new PageImpl<>(List.of(
@@ -467,6 +468,17 @@ class InstrumentQueryServiceTest {
 			"종로구",
 			EffectorType.GUITAR,
 			EffectorFeature.ETC
+		);
+	}
+
+	private AmplifierFilterConditions createAmplifierFilterConditions() throws Exception {
+		return ReflectionUtils.createAmplifierFilterConditions(
+			InstrumentProgressStatus.SELLING,
+			"서울특별시",
+			"종로구",
+			AmplifierType.GUITAR,
+			AmplifierBrand.FENDER,
+			AmplifierUsage.HOME
 		);
 	}
 }

--- a/src/test/java/com/ajou/hertz/util/ReflectionUtils.java
+++ b/src/test/java/com/ajou/hertz/util/ReflectionUtils.java
@@ -43,6 +43,7 @@ import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentImageDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
@@ -796,6 +797,22 @@ public class ReflectionUtils {
 		);
 		constructor.setAccessible(true);
 		return constructor.newInstance(progressStatus, sido, sgg, type, feature);
+	}
+
+	public static AmplifierFilterConditions createAmplifierFilterConditions(
+		InstrumentProgressStatus progressStatus,
+		String sido,
+		String sgg,
+		AmplifierType type,
+		AmplifierBrand brand,
+		AmplifierUsage usage
+	) throws Exception {
+		Constructor<AmplifierFilterConditions> constructor = AmplifierFilterConditions.class.getDeclaredConstructor(
+			InstrumentProgressStatus.class, String.class, String.class,
+			AmplifierType.class, AmplifierBrand.class, AmplifierUsage.class
+		);
+		constructor.setAccessible(true);
+		return constructor.newInstance(progressStatus, sido, sgg, type, brand, usage);
 	}
 
 	/**

--- a/src/test/java/com/ajou/hertz/util/ReflectionUtils.java
+++ b/src/test/java/com/ajou/hertz/util/ReflectionUtils.java
@@ -44,6 +44,7 @@ import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentImageDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
+import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
@@ -580,11 +581,12 @@ public class ReflectionUtils {
 		Short productionYear,
 		GuitarColor color
 	) throws Exception {
-		Constructor<CreateNewElectricGuitarRequest> constructor = CreateNewElectricGuitarRequest.class.getDeclaredConstructor(
-			String.class, List.class, InstrumentProgressStatus.class, AddressRequest.class,
-			Short.class, Integer.class, Boolean.class, String.class, ElectricGuitarBrand.class,
-			ElectricGuitarModel.class, Short.class, GuitarColor.class, List.class
-		);
+		Constructor<CreateNewElectricGuitarRequest> constructor =
+			CreateNewElectricGuitarRequest.class.getDeclaredConstructor(
+				String.class, List.class, InstrumentProgressStatus.class, AddressRequest.class,
+				Short.class, Integer.class, Boolean.class, String.class, ElectricGuitarBrand.class,
+				ElectricGuitarModel.class, Short.class, GuitarColor.class, List.class
+			);
 		constructor.setAccessible(true);
 		return constructor.newInstance(
 			title, images, progressStatus, tradeAddress, qualityStatus, price, hasAnomaly, description,
@@ -634,12 +636,13 @@ public class ReflectionUtils {
 		AcousticAndClassicGuitarWood wood,
 		AcousticAndClassicGuitarPickUp pickUp
 	) throws Exception {
-		Constructor<CreateNewAcousticAndClassicGuitarRequest> constructor = CreateNewAcousticAndClassicGuitarRequest.class.getDeclaredConstructor(
-			String.class, InstrumentProgressStatus.class, AddressRequest.class, Short.class,
-			Integer.class, Boolean.class, String.class, List.class, List.class,
-			AcousticAndClassicGuitarBrand.class, AcousticAndClassicGuitarModel.class,
-			AcousticAndClassicGuitarWood.class, AcousticAndClassicGuitarPickUp.class
-		);
+		Constructor<CreateNewAcousticAndClassicGuitarRequest> constructor =
+			CreateNewAcousticAndClassicGuitarRequest.class.getDeclaredConstructor(
+				String.class, InstrumentProgressStatus.class, AddressRequest.class, Short.class,
+				Integer.class, Boolean.class, String.class, List.class, List.class,
+				AcousticAndClassicGuitarBrand.class, AcousticAndClassicGuitarModel.class,
+				AcousticAndClassicGuitarWood.class, AcousticAndClassicGuitarPickUp.class
+			);
 		constructor.setAccessible(true);
 		return constructor.newInstance(
 			title, progressStatus, tradeAddress, qualityStatus, price, hasAnomaly, description, images, hashtags,
@@ -710,11 +713,12 @@ public class ReflectionUtils {
 		List<String> hashtags,
 		AudioEquipmentType type
 	) throws Exception {
-		Constructor<CreateNewAudioEquipmentRequest> constructor = CreateNewAudioEquipmentRequest.class.getDeclaredConstructor(
-			String.class, InstrumentProgressStatus.class, AddressRequest.class, Short.class,
-			Integer.class, Boolean.class, String.class, List.class, List.class,
-			AudioEquipmentType.class
-		);
+		Constructor<CreateNewAudioEquipmentRequest> constructor =
+			CreateNewAudioEquipmentRequest.class.getDeclaredConstructor(
+				String.class, InstrumentProgressStatus.class, AddressRequest.class, Short.class,
+				Integer.class, Boolean.class, String.class, List.class, List.class,
+				AudioEquipmentType.class
+			);
 		constructor.setAccessible(true);
 		return constructor.newInstance(
 			title, progressStatus, tradeAddress, qualityStatus, price, hasAnomaly, description, images, hashtags, type
@@ -741,10 +745,11 @@ public class ReflectionUtils {
 		ElectricGuitarModel model,
 		GuitarColor color
 	) throws Exception {
-		Constructor<ElectricGuitarFilterConditions> constructor = ElectricGuitarFilterConditions.class.getDeclaredConstructor(
-			InstrumentProgressStatus.class, String.class, String.class,
-			ElectricGuitarBrand.class, ElectricGuitarModel.class, GuitarColor.class
-		);
+		Constructor<ElectricGuitarFilterConditions> constructor =
+			ElectricGuitarFilterConditions.class.getDeclaredConstructor(
+				InstrumentProgressStatus.class, String.class, String.class,
+				ElectricGuitarBrand.class, ElectricGuitarModel.class, GuitarColor.class
+			);
 		constructor.setAccessible(true);
 		return constructor.newInstance(progressStatus, sido, sgg, brand, model, color);
 	}
@@ -775,11 +780,12 @@ public class ReflectionUtils {
 		AcousticAndClassicGuitarWood wood,
 		AcousticAndClassicGuitarPickUp pickUp
 	) throws Exception {
-		Constructor<AcousticAndClassicGuitarFilterConditions> constructor = AcousticAndClassicGuitarFilterConditions.class.getDeclaredConstructor(
-			InstrumentProgressStatus.class, String.class, String.class,
-			AcousticAndClassicGuitarBrand.class, AcousticAndClassicGuitarModel.class,
-			AcousticAndClassicGuitarWood.class, AcousticAndClassicGuitarPickUp.class
-		);
+		Constructor<AcousticAndClassicGuitarFilterConditions> constructor =
+			AcousticAndClassicGuitarFilterConditions.class.getDeclaredConstructor(
+				InstrumentProgressStatus.class, String.class, String.class,
+				AcousticAndClassicGuitarBrand.class, AcousticAndClassicGuitarModel.class,
+				AcousticAndClassicGuitarWood.class, AcousticAndClassicGuitarPickUp.class
+			);
 		constructor.setAccessible(true);
 		return constructor.newInstance(progressStatus, sido, sgg, brand, model, wood, pickUp);
 	}
@@ -813,6 +819,20 @@ public class ReflectionUtils {
 		);
 		constructor.setAccessible(true);
 		return constructor.newInstance(progressStatus, sido, sgg, type, brand, usage);
+	}
+
+	public static AudioEquipmentFilterConditions createAudioEquipmentFilterConditions(
+		InstrumentProgressStatus progressStatus,
+		String sido,
+		String sgg,
+		AudioEquipmentType type
+	) throws Exception {
+		Constructor<AudioEquipmentFilterConditions> constructor =
+			AudioEquipmentFilterConditions.class.getDeclaredConstructor(
+				InstrumentProgressStatus.class, String.class, String.class, AudioEquipmentType.class
+			);
+		constructor.setAccessible(true);
+		return constructor.newInstance(progressStatus, sido, sgg, type);
 	}
 
 	/**

--- a/src/test/java/com/ajou/hertz/util/ReflectionUtils.java
+++ b/src/test/java/com/ajou/hertz/util/ReflectionUtils.java
@@ -42,6 +42,7 @@ import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.InstrumentImageDto;
+import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAcousticAndClassicGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewAmplifierRequest;
@@ -761,6 +762,24 @@ public class ReflectionUtils {
 		);
 		constructor.setAccessible(true);
 		return constructor.newInstance(progressStatus, sido, sgg, brand, pickUp, preAmplifier, color);
+	}
+
+	public static AcousticAndClassicGuitarFilterConditions createAcousticAndClassicGuitarFilterConditions(
+		InstrumentProgressStatus progressStatus,
+		String sido,
+		String sgg,
+		AcousticAndClassicGuitarBrand brand,
+		AcousticAndClassicGuitarModel model,
+		AcousticAndClassicGuitarWood wood,
+		AcousticAndClassicGuitarPickUp pickUp
+	) throws Exception {
+		Constructor<AcousticAndClassicGuitarFilterConditions> constructor = AcousticAndClassicGuitarFilterConditions.class.getDeclaredConstructor(
+			InstrumentProgressStatus.class, String.class, String.class,
+			AcousticAndClassicGuitarBrand.class, AcousticAndClassicGuitarModel.class,
+			AcousticAndClassicGuitarWood.class, AcousticAndClassicGuitarPickUp.class
+		);
+		constructor.setAccessible(true);
+		return constructor.newInstance(progressStatus, sido, sgg, brand, model, wood, pickUp);
 	}
 
 	/**

--- a/src/test/java/com/ajou/hertz/util/ReflectionUtils.java
+++ b/src/test/java/com/ajou/hertz/util/ReflectionUtils.java
@@ -50,6 +50,7 @@ import com.ajou.hertz.domain.instrument.dto.request.CreateNewAudioEquipmentReque
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewBassGuitarRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewEffectorRequest;
 import com.ajou.hertz.domain.instrument.dto.request.CreateNewElectricGuitarRequest;
+import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.InstrumentFilterConditions;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
@@ -780,6 +781,21 @@ public class ReflectionUtils {
 		);
 		constructor.setAccessible(true);
 		return constructor.newInstance(progressStatus, sido, sgg, brand, model, wood, pickUp);
+	}
+
+	public static EffectorFilterConditions createEffectorFilterConditions(
+		InstrumentProgressStatus progressStatus,
+		String sido,
+		String sgg,
+		EffectorType type,
+		EffectorFeature feature
+	) throws Exception {
+		Constructor<EffectorFilterConditions> constructor = EffectorFilterConditions.class.getDeclaredConstructor(
+			InstrumentProgressStatus.class, String.class, String.class,
+			EffectorType.class, EffectorFeature.class
+		);
+		constructor.setAccessible(true);
+		return constructor.newInstance(progressStatus, sido, sgg, type, feature);
 	}
 
 	/**


### PR DESCRIPTION
## 🔥 Related Issue
- Close #67
- #74 

## 🏃‍ Task
- #74 에서 미구현했던 각 악기 종류별 필터링 조건 추가
- `InstrumentRepository` 리팩토링: 각 기능을 추상화하여 재사용성을 높이고 코드 가독성을 향상시킴

## 📄 Reference
- None
