### PR TITLE
악기 매물 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
+++ b/src/main/java/com/ajou/hertz/common/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
 		AUTH_WHITE_LIST.put("/api/administrative-areas/sgg", GET);
 		AUTH_WHITE_LIST.put("/api/administrative-areas/emd", GET);
 		AUTH_WHITE_LIST.put("/api/instruments", GET);
+		AUTH_WHITE_LIST.put("/api/instruments/{instrumentId:\\d+}", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/electric-guitars", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/bass-guitars", GET);
 		AUTH_WHITE_LIST.put("/api/instruments/acoustic-and-classic-guitars", GET);

--- a/src/main/java/com/ajou/hertz/common/exception/constant/CustomExceptionType.java
+++ b/src/main/java/com/ajou/hertz/common/exception/constant/CustomExceptionType.java
@@ -12,6 +12,7 @@ import lombok.Getter;
  *     <li>2000 ~ 2199: 인증 관련 예외</li>
  *     <li>2200 ~ 2399: 유저 관련 예외</li>
  *     <li>2400 ~ 2599: 주소 관련 예외</li>
+ *     <li>2600 ~ 2799: 악기 관련 예외</li>
  * </ul>
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -46,6 +47,11 @@ public enum CustomExceptionType {
 	 * 주소 관련 예외
 	 */
 	INVALID_ADDRESS_FORMAT(2400, "주소 형식이 올바르지 않습니다."),
+
+	/**
+	 * 악기 관련 예외
+	 */
+	INSTRUMENT_NOT_FOUND_BY_ID(2600, "일치하는 매물 정보를 찾을 수 없습니다.")
 	;
 
 	private final Integer code;

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -81,7 +81,7 @@ public class InstrumentController {
 		) @RequestParam InstrumentSortOption sort
 	) {
 		return instrumentQueryService
-			.findInstruments(page, size, sort)
+			.findInstrumentDtos(page, size, sort)
 			.map(InstrumentSummaryResponse::from);
 	}
 
@@ -105,7 +105,7 @@ public class InstrumentController {
 		@ParameterObject @Valid @ModelAttribute ElectricGuitarFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findElectricGuitars(page, size, sort, filterConditions)
+			.findElectricGuitarDtos(page, size, sort, filterConditions)
 			.map(ElectricGuitarResponse::from);
 	}
 
@@ -129,7 +129,7 @@ public class InstrumentController {
 		@ParameterObject @Valid @ModelAttribute BassGuitarFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findBassGuitars(page, size, sort, filterConditions)
+			.findBassGuitarDtos(page, size, sort, filterConditions)
 			.map(BassGuitarResponse::from);
 	}
 
@@ -153,7 +153,7 @@ public class InstrumentController {
 		@ParameterObject @Valid @ModelAttribute AcousticAndClassicGuitarFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findAcousticAndClassicGuitars(page, size, sort, filterConditions)
+			.findAcousticAndClassicGuitarDtos(page, size, sort, filterConditions)
 			.map(AcousticAndClassicGuitarResponse::from);
 	}
 
@@ -177,7 +177,7 @@ public class InstrumentController {
 		@ParameterObject @Valid @ModelAttribute EffectorFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findEffectors(page, size, sort, filterConditions)
+			.findEffectorDtos(page, size, sort, filterConditions)
 			.map(EffectorResponse::from);
 	}
 
@@ -201,7 +201,7 @@ public class InstrumentController {
 		@ParameterObject @Valid @ModelAttribute AmplifierFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findAmplifiers(page, size, sort, filterConditions)
+			.findAmplifierDtos(page, size, sort, filterConditions)
 			.map(AmplifierResponse::from);
 	}
 
@@ -225,7 +225,7 @@ public class InstrumentController {
 		@ParameterObject @Valid @ModelAttribute AudioEquipmentFilterConditions filterConditions
 	) {
 		return instrumentQueryService
-			.findAudioEquipments(page, size, sort, filterConditions)
+			.findAudioEquipmentDtos(page, size, sort, filterConditions)
 			.map(AudioEquipmentResponse::from);
 	}
 

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -24,6 +25,7 @@ import com.ajou.hertz.domain.instrument.dto.AudioEquipmentDto;
 import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.EffectorDto;
 import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 import com.ajou.hertz.domain.instrument.dto.request.AcousticAndClassicGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AmplifierFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditions;
@@ -42,7 +44,9 @@ import com.ajou.hertz.domain.instrument.dto.response.AudioEquipmentResponse;
 import com.ajou.hertz.domain.instrument.dto.response.BassGuitarResponse;
 import com.ajou.hertz.domain.instrument.dto.response.EffectorResponse;
 import com.ajou.hertz.domain.instrument.dto.response.ElectricGuitarResponse;
+import com.ajou.hertz.domain.instrument.dto.response.InstrumentResponse;
 import com.ajou.hertz.domain.instrument.dto.response.InstrumentSummaryResponse;
+import com.ajou.hertz.domain.instrument.mapper.InstrumentMapper;
 import com.ajou.hertz.domain.instrument.service.InstrumentCommandService;
 import com.ajou.hertz.domain.instrument.service.InstrumentQueryService;
 
@@ -61,6 +65,28 @@ public class InstrumentController {
 
 	private final InstrumentCommandService instrumentCommandService;
 	private final InstrumentQueryService instrumentQueryService;
+
+	@Operation(
+		summary = "악기 매물 상세 조회",
+		description = """
+			<p>매물의 상세 정보를 조회합니다.
+			<p>악기 종류별로 응답 데이터가 다를 수 있습니다.
+			<p>정확한 악기 종류별 응답 데이터는 페이지 하단의 <b>Schemas</b> 항목에서 아래 내용들을 참고해주세요.
+			<ul>
+				<li>일렉 기타 응답 데이터: <code>ElectricGuitarResponse</code></li>
+				<li>베이스 기타 응답 데이터: <code>BassGuitarResponse</code></li>
+				<li>어쿠스틱&클래식 기타 응답 데이터: <code>AcousticAndClassicGuitarResponse</code></li>
+				<li>이펙터 응답 데이터: <code>EffectorResponse</code></li>
+				<li>앰프 응답 데이터: <code>AmplifierResponse</code></li>
+				<li>음향 장비 응답 데이터: <code>AudioEquipmentResponse</code></li>
+			</ul>
+			"""
+	)
+	@GetMapping(value = "/{instrumentId}", headers = API_VERSION_HEADER_NAME + "=" + 1)
+	public InstrumentResponse getInstrumentByIdV1(@PathVariable Long instrumentId) {
+		InstrumentDto instrumentDto = instrumentQueryService.getInstrumentDtoById(instrumentId);
+		return InstrumentMapper.toResponse(instrumentDto);
+	}
 
 	@Operation(
 		summary = "전체 악기 매물 목록 조회",

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -108,7 +108,7 @@ public class InstrumentController {
 	) {
 		return instrumentQueryService
 			.findInstrumentDtos(page, size, sort)
-			.map(InstrumentSummaryResponse::from);
+			.map(InstrumentMapper::toInstrumentSummaryResponse);
 	}
 
 	@Operation(
@@ -132,7 +132,7 @@ public class InstrumentController {
 	) {
 		return instrumentQueryService
 			.findElectricGuitarDtos(page, size, sort, filterConditions)
-			.map(ElectricGuitarResponse::from);
+			.map(InstrumentMapper::toElectricGuitarResponse);
 	}
 
 	@Operation(
@@ -156,7 +156,7 @@ public class InstrumentController {
 	) {
 		return instrumentQueryService
 			.findBassGuitarDtos(page, size, sort, filterConditions)
-			.map(BassGuitarResponse::from);
+			.map(InstrumentMapper::toBassGuitarResponse);
 	}
 
 	@Operation(
@@ -180,7 +180,7 @@ public class InstrumentController {
 	) {
 		return instrumentQueryService
 			.findAcousticAndClassicGuitarDtos(page, size, sort, filterConditions)
-			.map(AcousticAndClassicGuitarResponse::from);
+			.map(InstrumentMapper::toAcousticAndClassicGuitarResponse);
 	}
 
 	@Operation(
@@ -204,7 +204,7 @@ public class InstrumentController {
 	) {
 		return instrumentQueryService
 			.findEffectorDtos(page, size, sort, filterConditions)
-			.map(EffectorResponse::from);
+			.map(InstrumentMapper::toEffectorResponse);
 	}
 
 	@Operation(
@@ -228,7 +228,7 @@ public class InstrumentController {
 	) {
 		return instrumentQueryService
 			.findAmplifierDtos(page, size, sort, filterConditions)
-			.map(AmplifierResponse::from);
+			.map(InstrumentMapper::toAmplifierResponse);
 	}
 
 	@Operation(
@@ -252,7 +252,7 @@ public class InstrumentController {
 	) {
 		return instrumentQueryService
 			.findAudioEquipmentDtos(page, size, sort, filterConditions)
-			.map(AudioEquipmentResponse::from);
+			.map(InstrumentMapper::toAudioEquipmentResponse);
 	}
 
 	@Operation(
@@ -278,7 +278,7 @@ public class InstrumentController {
 		);
 		return ResponseEntity
 			.created(URI.create("/instruments/" + electricGuitar.getId()))
-			.body(ElectricGuitarResponse.from(electricGuitar));
+			.body(InstrumentMapper.toElectricGuitarResponse(electricGuitar));
 	}
 
 	@Operation(
@@ -304,7 +304,7 @@ public class InstrumentController {
 		);
 		return ResponseEntity
 			.created(URI.create("/instruments/" + bassGuitar.getId()))
-			.body(BassGuitarResponse.from(bassGuitar));
+			.body(InstrumentMapper.toBassGuitarResponse(bassGuitar));
 	}
 
 	@Operation(
@@ -331,7 +331,7 @@ public class InstrumentController {
 			);
 		return ResponseEntity
 			.created(URI.create("/instruments/" + acousticAndClassicGuitar.getId()))
-			.body(AcousticAndClassicGuitarResponse.from(acousticAndClassicGuitar));
+			.body(InstrumentMapper.toAcousticAndClassicGuitarResponse(acousticAndClassicGuitar));
 	}
 
 	@Operation(
@@ -357,7 +357,7 @@ public class InstrumentController {
 		);
 		return ResponseEntity
 			.created(URI.create("/instruments/" + effector.getId()))
-			.body(EffectorResponse.from(effector));
+			.body(InstrumentMapper.toEffectorResponse(effector));
 	}
 
 	@Operation(
@@ -383,7 +383,7 @@ public class InstrumentController {
 		);
 		return ResponseEntity
 			.created(URI.create("/instruments/" + amplifier.getId()))
-			.body(AmplifierResponse.from(amplifier));
+			.body(InstrumentMapper.toAmplifierResponse(amplifier));
 	}
 
 	@Operation(
@@ -409,6 +409,6 @@ public class InstrumentController {
 		);
 		return ResponseEntity
 			.created(URI.create("/instruments/" + audioEquipment.getId()))
-			.body(AudioEquipmentResponse.from(audioEquipment));
+			.body(InstrumentMapper.toAudioEquipmentResponse(audioEquipment));
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/AcousticAndClassicGuitarDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/AcousticAndClassicGuitarDto.java
@@ -52,7 +52,7 @@ public class AcousticAndClassicGuitarDto extends InstrumentDto {
 		this.pickUp = pickUp;
 	}
 
-	private AcousticAndClassicGuitarDto(AcousticAndClassicGuitar acousticAndClassicGuitar) {
+	public AcousticAndClassicGuitarDto(AcousticAndClassicGuitar acousticAndClassicGuitar) {
 		super(
 			acousticAndClassicGuitar
 		);
@@ -60,9 +60,5 @@ public class AcousticAndClassicGuitarDto extends InstrumentDto {
 		this.model = acousticAndClassicGuitar.getModel();
 		this.wood = acousticAndClassicGuitar.getWood();
 		this.pickUp = acousticAndClassicGuitar.getPickUp();
-	}
-
-	public static AcousticAndClassicGuitarDto from(AcousticAndClassicGuitar acousticAndClassicGuitar) {
-		return new AcousticAndClassicGuitarDto(acousticAndClassicGuitar);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/AmplifierDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/AmplifierDto.java
@@ -48,14 +48,10 @@ public class AmplifierDto extends InstrumentDto {
 		this.usage = usage;
 	}
 
-	private AmplifierDto(Amplifier amplifier) {
+	public AmplifierDto(Amplifier amplifier) {
 		super(amplifier);
 		this.type = amplifier.getType();
 		this.brand = amplifier.getBrand();
 		this.usage = amplifier.getUsage();
-	}
-
-	public static AmplifierDto from(Amplifier amplifier) {
-		return new AmplifierDto(amplifier);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/AudioEquipmentDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/AudioEquipmentDto.java
@@ -40,12 +40,8 @@ public class AudioEquipmentDto extends InstrumentDto {
 		this.type = type;
 	}
 
-	private AudioEquipmentDto(AudioEquipment audioEquipment) {
+	public AudioEquipmentDto(AudioEquipment audioEquipment) {
 		super(audioEquipment);
 		this.type = audioEquipment.getType();
-	}
-
-	public static AudioEquipmentDto from(AudioEquipment audioEquipment) {
-		return new AudioEquipmentDto(audioEquipment);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/BassGuitarDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/BassGuitarDto.java
@@ -52,15 +52,11 @@ public class BassGuitarDto extends InstrumentDto {
 		this.color = color;
 	}
 
-	private BassGuitarDto(BassGuitar bassGuitar) {
+	public BassGuitarDto(BassGuitar bassGuitar) {
 		super(bassGuitar);
 		this.brand = bassGuitar.getBrand();
 		this.pickUp = bassGuitar.getPickUp();
 		this.preAmplifier = bassGuitar.getPreAmplifier();
 		this.color = bassGuitar.getColor();
-	}
-
-	public static BassGuitarDto from(BassGuitar bassGuitar) {
-		return new BassGuitarDto(bassGuitar);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/EffectorDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/EffectorDto.java
@@ -44,13 +44,9 @@ public class EffectorDto extends InstrumentDto {
 		this.feature = feature;
 	}
 
-	private EffectorDto(Effector effector) {
+	public EffectorDto(Effector effector) {
 		super(effector);
 		this.type = effector.getType();
 		this.feature = effector.getFeature();
-	}
-
-	public static EffectorDto from(Effector effector) {
-		return new EffectorDto(effector);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/ElectricGuitarDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/ElectricGuitarDto.java
@@ -51,15 +51,11 @@ public class ElectricGuitarDto extends InstrumentDto {
 		this.color = color;
 	}
 
-	private ElectricGuitarDto(ElectricGuitar electricGuitar) {
+	public ElectricGuitarDto(ElectricGuitar electricGuitar) {
 		super(electricGuitar);
 		this.brand = electricGuitar.getBrand();
 		this.model = electricGuitar.getModel();
 		this.productionYear = electricGuitar.getProductionYear();
 		this.color = electricGuitar.getColor();
-	}
-
-	public static ElectricGuitarDto from(ElectricGuitar electricGuitar) {
-		return new ElectricGuitarDto(electricGuitar);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/InstrumentDto.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/InstrumentDto.java
@@ -64,23 +64,6 @@ public class InstrumentDto {
 		);
 	}
 
-	public static InstrumentDto from(Instrument instrument) {
-		return new InstrumentDto(
-			instrument.getId(),
-			UserDto.from(instrument.getSeller()),
-			getInstrumentCategory(instrument.getClass()),
-			instrument.getTitle(),
-			instrument.getProgressStatus(),
-			AddressDto.from(instrument.getTradeAddress()),
-			instrument.getQualityStatus(),
-			instrument.getPrice(),
-			instrument.getHasAnomaly(),
-			instrument.getDescription(),
-			instrument.getImages().toDtos(),
-			instrument.getHashtags().toStrings()
-		);
-	}
-
 	private static InstrumentCategory getInstrumentCategory(Class<? extends Instrument> instrumentClassType) {
 		if (!instrumentCategoryMap.containsKey(instrumentClassType)) {
 			throw new IllegalArgumentException("Unsupported instrument class: " + instrumentClassType.getName());

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/AcousticAndClassicGuitarResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/AcousticAndClassicGuitarResponse.java
@@ -59,15 +59,11 @@ public class AcousticAndClassicGuitarResponse extends InstrumentResponse {
 		this.pickUp = pickUp;
 	}
 
-	private AcousticAndClassicGuitarResponse(AcousticAndClassicGuitarDto acousticAndClassicGuitarDto) {
+	public AcousticAndClassicGuitarResponse(AcousticAndClassicGuitarDto acousticAndClassicGuitarDto) {
 		super(acousticAndClassicGuitarDto);
 		this.brand = acousticAndClassicGuitarDto.getBrand();
 		this.model = acousticAndClassicGuitarDto.getModel();
 		this.wood = acousticAndClassicGuitarDto.getWood();
 		this.pickUp = acousticAndClassicGuitarDto.getPickUp();
-	}
-
-	public static AcousticAndClassicGuitarResponse from(AcousticAndClassicGuitarDto acousticAndClassicGuitarDto) {
-		return new AcousticAndClassicGuitarResponse(acousticAndClassicGuitarDto);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/AmplifierResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/AmplifierResponse.java
@@ -53,14 +53,10 @@ public class AmplifierResponse extends InstrumentResponse {
 		this.usage = usage;
 	}
 
-	private AmplifierResponse(AmplifierDto amplifierDto) {
+	public AmplifierResponse(AmplifierDto amplifierDto) {
 		super(amplifierDto);
 		this.type = amplifierDto.getType();
 		this.brand = amplifierDto.getBrand();
 		this.usage = amplifierDto.getUsage();
-	}
-
-	public static AmplifierResponse from(AmplifierDto amplifierDto) {
-		return new AmplifierResponse(amplifierDto);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/AudioEquipmentResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/AudioEquipmentResponse.java
@@ -41,12 +41,8 @@ public class AudioEquipmentResponse extends InstrumentResponse {
 		this.type = type;
 	}
 
-	private AudioEquipmentResponse(AudioEquipmentDto audioEquipmentDto) {
+	public AudioEquipmentResponse(AudioEquipmentDto audioEquipmentDto) {
 		super(audioEquipmentDto);
 		this.type = audioEquipmentDto.getType();
-	}
-
-	public static AudioEquipmentResponse from(AudioEquipmentDto audioEquipmentDto) {
-		return new AudioEquipmentResponse(audioEquipmentDto);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/BassGuitarResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/BassGuitarResponse.java
@@ -59,15 +59,11 @@ public class BassGuitarResponse extends InstrumentResponse {
 		this.color = color;
 	}
 
-	private BassGuitarResponse(BassGuitarDto bassGuitarDto) {
+	public BassGuitarResponse(BassGuitarDto bassGuitarDto) {
 		super(bassGuitarDto);
 		this.brand = bassGuitarDto.getBrand();
 		this.pickUp = bassGuitarDto.getPickUp();
 		this.preAmplifier = bassGuitarDto.getPreAmplifier();
 		this.color = bassGuitarDto.getColor();
-	}
-
-	public static BassGuitarResponse from(BassGuitarDto bassGuitarDto) {
-		return new BassGuitarResponse(bassGuitarDto);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/EffectorResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/EffectorResponse.java
@@ -47,13 +47,9 @@ public class EffectorResponse extends InstrumentResponse {
 		this.feature = feature;
 	}
 
-	private EffectorResponse(EffectorDto effectorDto) {
+	public EffectorResponse(EffectorDto effectorDto) {
 		super(effectorDto);
 		this.type = effectorDto.getType();
 		this.feature = effectorDto.getFeature();
-	}
-
-	public static EffectorResponse from(EffectorDto effectorDto) {
-		return new EffectorResponse(effectorDto);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/ElectricGuitarResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/ElectricGuitarResponse.java
@@ -58,15 +58,11 @@ public class ElectricGuitarResponse extends InstrumentResponse {
 		this.color = color;
 	}
 
-	private ElectricGuitarResponse(ElectricGuitarDto electricGuitarDto) {
+	public ElectricGuitarResponse(ElectricGuitarDto electricGuitarDto) {
 		super(electricGuitarDto);
 		this.brand = electricGuitarDto.getBrand();
 		this.model = electricGuitarDto.getModel();
 		this.productionYear = electricGuitarDto.getProductionYear();
 		this.color = electricGuitarDto.getColor();
-	}
-
-	public static ElectricGuitarResponse from(ElectricGuitarDto electricGuitarDto) {
-		return new ElectricGuitarResponse(electricGuitarDto);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/InstrumentImageResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/InstrumentImageResponse.java
@@ -3,6 +3,7 @@ package com.ajou.hertz.domain.instrument.dto.response;
 import com.ajou.hertz.domain.instrument.dto.InstrumentImageDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,7 +23,10 @@ public class InstrumentImageResponse {
 	@Schema(description = "이미지 url", example = "https://instrument-image-url")
 	private String url;
 
-	public static InstrumentImageResponse from(InstrumentImageDto instrumentImageDto) {
+	public static InstrumentImageResponse from(@Nullable InstrumentImageDto instrumentImageDto) {
+		if (instrumentImageDto == null) {
+			return null;
+		}
 		return new InstrumentImageResponse(
 			instrumentImageDto.getId(),
 			instrumentImageDto.getName(),

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/InstrumentResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/InstrumentResponse.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public abstract class InstrumentResponse {
 
-	@Schema(description = "Id of instrument(electric guitar)", example = "2")
+	@Schema(description = "Id of instrument", example = "2")
 	private Long id;
 
 	@Schema(description = "Id of seller", example = "1")

--- a/src/main/java/com/ajou/hertz/domain/instrument/dto/response/InstrumentSummaryResponse.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/dto/response/InstrumentSummaryResponse.java
@@ -3,7 +3,6 @@ package com.ajou.hertz.domain.instrument.dto.response;
 import com.ajou.hertz.common.dto.response.AddressResponse;
 import com.ajou.hertz.domain.instrument.constant.InstrumentCategory;
 import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
-import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -11,7 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class InstrumentSummaryResponse {
@@ -36,16 +35,4 @@ public class InstrumentSummaryResponse {
 
 	@Schema(description = "악기 썸네일 이미지")
 	private InstrumentImageResponse thumbnailImage;
-
-	public static InstrumentSummaryResponse from(InstrumentDto instrumentDto) {
-		return new InstrumentSummaryResponse(
-			instrumentDto.getId(),
-			instrumentDto.getCategory(),
-			instrumentDto.getTitle(),
-			instrumentDto.getProgressStatus(),
-			AddressResponse.from(instrumentDto.getTradeAddress()),
-			instrumentDto.getPrice(),
-			InstrumentImageResponse.from(instrumentDto.getImages().get(0))
-		);
-	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/exception/InstrumentNotFoundByIdException.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/exception/InstrumentNotFoundByIdException.java
@@ -1,0 +1,11 @@
+package com.ajou.hertz.domain.instrument.exception;
+
+import com.ajou.hertz.common.exception.NotFoundException;
+import com.ajou.hertz.common.exception.constant.CustomExceptionType;
+
+public class InstrumentNotFoundByIdException extends NotFoundException {
+
+	public InstrumentNotFoundByIdException(Long id) {
+		super(CustomExceptionType.INSTRUMENT_NOT_FOUND_BY_ID, "id=" + id);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/mapper/InstrumentMapper.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/mapper/InstrumentMapper.java
@@ -1,0 +1,62 @@
+package com.ajou.hertz.domain.instrument.mapper;
+
+import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.AmplifierDto;
+import com.ajou.hertz.domain.instrument.dto.AudioEquipmentDto;
+import com.ajou.hertz.domain.instrument.dto.BassGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.EffectorDto;
+import com.ajou.hertz.domain.instrument.dto.ElectricGuitarDto;
+import com.ajou.hertz.domain.instrument.dto.InstrumentDto;
+import com.ajou.hertz.domain.instrument.dto.response.AcousticAndClassicGuitarResponse;
+import com.ajou.hertz.domain.instrument.dto.response.AmplifierResponse;
+import com.ajou.hertz.domain.instrument.dto.response.AudioEquipmentResponse;
+import com.ajou.hertz.domain.instrument.dto.response.BassGuitarResponse;
+import com.ajou.hertz.domain.instrument.dto.response.EffectorResponse;
+import com.ajou.hertz.domain.instrument.dto.response.ElectricGuitarResponse;
+import com.ajou.hertz.domain.instrument.dto.response.InstrumentResponse;
+import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
+import com.ajou.hertz.domain.instrument.entity.Amplifier;
+import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.Effector;
+import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class InstrumentMapper {
+
+	public static InstrumentDto toDto(Instrument instrument) {
+		if (instrument instanceof ElectricGuitar) {
+			return ElectricGuitarDto.from((ElectricGuitar)instrument);
+		} else if (instrument instanceof BassGuitar) {
+			return BassGuitarDto.from((BassGuitar)instrument);
+		} else if (instrument instanceof AcousticAndClassicGuitar) {
+			return AcousticAndClassicGuitarDto.from((AcousticAndClassicGuitar)instrument);
+		} else if (instrument instanceof Effector) {
+			return EffectorDto.from((Effector)instrument);
+		} else if (instrument instanceof Amplifier) {
+			return AmplifierDto.from((Amplifier)instrument);
+		} else {
+			return AudioEquipmentDto.from((AudioEquipment)instrument);
+		}
+	}
+
+	public static InstrumentResponse toResponse(InstrumentDto instrumentDto) {
+		if (instrumentDto instanceof ElectricGuitarDto) {
+			return ElectricGuitarResponse.from((ElectricGuitarDto)instrumentDto);
+		} else if (instrumentDto instanceof BassGuitarDto) {
+			return BassGuitarResponse.from((BassGuitarDto)instrumentDto);
+		} else if (instrumentDto instanceof AcousticAndClassicGuitarDto) {
+			return AcousticAndClassicGuitarResponse.from((AcousticAndClassicGuitarDto)instrumentDto);
+		} else if (instrumentDto instanceof EffectorDto) {
+			return EffectorResponse.from((EffectorDto)instrumentDto);
+		} else if (instrumentDto instanceof AmplifierDto) {
+			return AmplifierResponse.from((AmplifierDto)instrumentDto);
+		} else {
+			return AudioEquipmentResponse.from((AudioEquipmentDto)instrumentDto);
+		}
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/mapper/InstrumentMapper.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/mapper/InstrumentMapper.java
@@ -1,5 +1,6 @@
 package com.ajou.hertz.domain.instrument.mapper;
 
+import com.ajou.hertz.common.dto.response.AddressResponse;
 import com.ajou.hertz.domain.instrument.dto.AcousticAndClassicGuitarDto;
 import com.ajou.hertz.domain.instrument.dto.AmplifierDto;
 import com.ajou.hertz.domain.instrument.dto.AudioEquipmentDto;
@@ -13,7 +14,9 @@ import com.ajou.hertz.domain.instrument.dto.response.AudioEquipmentResponse;
 import com.ajou.hertz.domain.instrument.dto.response.BassGuitarResponse;
 import com.ajou.hertz.domain.instrument.dto.response.EffectorResponse;
 import com.ajou.hertz.domain.instrument.dto.response.ElectricGuitarResponse;
+import com.ajou.hertz.domain.instrument.dto.response.InstrumentImageResponse;
 import com.ajou.hertz.domain.instrument.dto.response.InstrumentResponse;
+import com.ajou.hertz.domain.instrument.dto.response.InstrumentSummaryResponse;
 import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
 import com.ajou.hertz.domain.instrument.entity.Amplifier;
 import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
@@ -30,33 +33,99 @@ public class InstrumentMapper {
 
 	public static InstrumentDto toDto(Instrument instrument) {
 		if (instrument instanceof ElectricGuitar) {
-			return ElectricGuitarDto.from((ElectricGuitar)instrument);
+			return new ElectricGuitarDto((ElectricGuitar)instrument);
 		} else if (instrument instanceof BassGuitar) {
-			return BassGuitarDto.from((BassGuitar)instrument);
+			return new BassGuitarDto((BassGuitar)instrument);
 		} else if (instrument instanceof AcousticAndClassicGuitar) {
-			return AcousticAndClassicGuitarDto.from((AcousticAndClassicGuitar)instrument);
+			return new AcousticAndClassicGuitarDto((AcousticAndClassicGuitar)instrument);
 		} else if (instrument instanceof Effector) {
-			return EffectorDto.from((Effector)instrument);
+			return new EffectorDto((Effector)instrument);
 		} else if (instrument instanceof Amplifier) {
-			return AmplifierDto.from((Amplifier)instrument);
+			return new AmplifierDto((Amplifier)instrument);
 		} else {
-			return AudioEquipmentDto.from((AudioEquipment)instrument);
+			return new AudioEquipmentDto((AudioEquipment)instrument);
 		}
+	}
+
+	public static ElectricGuitarDto toElectricGuitarDto(ElectricGuitar electricGuitar) {
+		return new ElectricGuitarDto(electricGuitar);
+	}
+
+	public static BassGuitarDto toBassGuitarDto(BassGuitar bassGuitar) {
+		return new BassGuitarDto(bassGuitar);
+	}
+
+	public static AcousticAndClassicGuitarDto toAcousticAndClassicGuitarDto(
+		AcousticAndClassicGuitar acousticAndClassicGuitar
+	) {
+		return new AcousticAndClassicGuitarDto(acousticAndClassicGuitar);
+	}
+
+	public static EffectorDto toEffectorDto(Effector effector) {
+		return new EffectorDto(effector);
+	}
+
+	public static AmplifierDto toAmplifierDto(Amplifier amplifier) {
+		return new AmplifierDto(amplifier);
+	}
+
+	public static AudioEquipmentDto toAmplifierDto(AudioEquipment audioEquipment) {
+		return new AudioEquipmentDto(audioEquipment);
 	}
 
 	public static InstrumentResponse toResponse(InstrumentDto instrumentDto) {
 		if (instrumentDto instanceof ElectricGuitarDto) {
-			return ElectricGuitarResponse.from((ElectricGuitarDto)instrumentDto);
+			return new ElectricGuitarResponse((ElectricGuitarDto)instrumentDto);
 		} else if (instrumentDto instanceof BassGuitarDto) {
-			return BassGuitarResponse.from((BassGuitarDto)instrumentDto);
+			return new BassGuitarResponse((BassGuitarDto)instrumentDto);
 		} else if (instrumentDto instanceof AcousticAndClassicGuitarDto) {
-			return AcousticAndClassicGuitarResponse.from((AcousticAndClassicGuitarDto)instrumentDto);
+			return new AcousticAndClassicGuitarResponse((AcousticAndClassicGuitarDto)instrumentDto);
 		} else if (instrumentDto instanceof EffectorDto) {
-			return EffectorResponse.from((EffectorDto)instrumentDto);
+			return new EffectorResponse((EffectorDto)instrumentDto);
 		} else if (instrumentDto instanceof AmplifierDto) {
-			return AmplifierResponse.from((AmplifierDto)instrumentDto);
+			return new AmplifierResponse((AmplifierDto)instrumentDto);
 		} else {
-			return AudioEquipmentResponse.from((AudioEquipmentDto)instrumentDto);
+			return new AudioEquipmentResponse((AudioEquipmentDto)instrumentDto);
 		}
+	}
+
+	public static InstrumentSummaryResponse toInstrumentSummaryResponse(InstrumentDto instrumentDto) {
+		return new InstrumentSummaryResponse(
+			instrumentDto.getId(),
+			instrumentDto.getCategory(),
+			instrumentDto.getTitle(),
+			instrumentDto.getProgressStatus(),
+			AddressResponse.from(instrumentDto.getTradeAddress()),
+			instrumentDto.getPrice(),
+			InstrumentImageResponse.from(
+				instrumentDto.getImages().isEmpty() ? null : instrumentDto.getImages().get(0)
+			)
+		);
+	}
+
+	public static ElectricGuitarResponse toElectricGuitarResponse(ElectricGuitarDto electricGuitarDto) {
+		return new ElectricGuitarResponse(electricGuitarDto);
+	}
+
+	public static BassGuitarResponse toBassGuitarResponse(BassGuitarDto bassGuitarDto) {
+		return new BassGuitarResponse(bassGuitarDto);
+	}
+
+	public static AcousticAndClassicGuitarResponse toAcousticAndClassicGuitarResponse(
+		AcousticAndClassicGuitarDto acousticAndClassicGuitarDto
+	) {
+		return new AcousticAndClassicGuitarResponse(acousticAndClassicGuitarDto);
+	}
+
+	public static EffectorResponse toEffectorResponse(EffectorDto effectorDto) {
+		return new EffectorResponse(effectorDto);
+	}
+
+	public static AmplifierResponse toAmplifierResponse(AmplifierDto amplifierDto) {
+		return new AmplifierResponse(amplifierDto);
+	}
+
+	public static AudioEquipmentResponse toAudioEquipmentResponse(AudioEquipmentDto audioEquipmentDto) {
+		return new AudioEquipmentResponse(audioEquipmentDto);
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentCommandService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentCommandService.java
@@ -29,6 +29,7 @@ import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.ajou.hertz.domain.instrument.entity.InstrumentHashtag;
 import com.ajou.hertz.domain.instrument.entity.InstrumentImage;
+import com.ajou.hertz.domain.instrument.mapper.InstrumentMapper;
 import com.ajou.hertz.domain.instrument.repository.InstrumentHashtagRepository;
 import com.ajou.hertz.domain.instrument.repository.InstrumentImageRepository;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
@@ -66,7 +67,7 @@ public class InstrumentCommandService {
 	 */
 	public ElectricGuitarDto createNewElectricGuitar(Long sellerId, CreateNewElectricGuitarRequest request) {
 		ElectricGuitar electricGuitar = createNewInstrument(sellerId, request, new ElectricGuitarCreationStrategy());
-		return ElectricGuitarDto.from(electricGuitar);
+		return InstrumentMapper.toElectricGuitarDto(electricGuitar);
 	}
 
 	/**
@@ -78,7 +79,7 @@ public class InstrumentCommandService {
 	 */
 	public BassGuitarDto createNewBassGuitar(Long sellerId, CreateNewBassGuitarRequest request) {
 		BassGuitar bassGuitar = createNewInstrument(sellerId, request, new BassGuitarCreationStrategy());
-		return BassGuitarDto.from(bassGuitar);
+		return InstrumentMapper.toBassGuitarDto(bassGuitar);
 	}
 
 	/**
@@ -97,7 +98,7 @@ public class InstrumentCommandService {
 			request,
 			new AcousticAndClassicGuitarCreationStrategy()
 		);
-		return AcousticAndClassicGuitarDto.from(acousticAndClassicGuitar);
+		return InstrumentMapper.toAcousticAndClassicGuitarDto(acousticAndClassicGuitar);
 	}
 
 	/**
@@ -109,7 +110,7 @@ public class InstrumentCommandService {
 	 */
 	public EffectorDto createNewEffector(Long sellerId, CreateNewEffectorRequest request) {
 		Effector effector = createNewInstrument(sellerId, request, new EffectorCreationStrategy());
-		return EffectorDto.from(effector);
+		return InstrumentMapper.toEffectorDto(effector);
 	}
 
 	/**
@@ -121,7 +122,7 @@ public class InstrumentCommandService {
 	 */
 	public AmplifierDto createNewAmplifier(Long sellerId, CreateNewAmplifierRequest request) {
 		Amplifier amplifier = createNewInstrument(sellerId, request, new AmplifierCreationStrategy());
-		return AmplifierDto.from(amplifier);
+		return InstrumentMapper.toAmplifierDto(amplifier);
 	}
 
 	/**
@@ -133,7 +134,7 @@ public class InstrumentCommandService {
 	 */
 	public AudioEquipmentDto createNewAudioEquipment(Long sellerId, CreateNewAudioEquipmentRequest request) {
 		AudioEquipment audioEquipment = createNewInstrument(sellerId, request, new AudioEquipmentCreationStrategy());
-		return AudioEquipmentDto.from(audioEquipment);
+		return InstrumentMapper.toAmplifierDto(audioEquipment);
 	}
 
 	/**

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -30,13 +30,13 @@ public class InstrumentQueryService {
 
 	private final InstrumentRepository instrumentRepository;
 
-	public Page<InstrumentDto> findInstruments(int page, int pageSize, InstrumentSortOption sort) {
+	public Page<InstrumentDto> findInstrumentDtos(int page, int pageSize, InstrumentSortOption sort) {
 		return instrumentRepository
 			.findAll(PageRequest.of(page, pageSize, sort.toSort()))
 			.map(InstrumentDto::from);
 	}
 
-	public Page<ElectricGuitarDto> findElectricGuitars(
+	public Page<ElectricGuitarDto> findElectricGuitarDtos(
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
@@ -47,7 +47,7 @@ public class InstrumentQueryService {
 			.map(ElectricGuitarDto::from);
 	}
 
-	public Page<BassGuitarDto> findBassGuitars(
+	public Page<BassGuitarDto> findBassGuitarDtos(
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
@@ -58,7 +58,7 @@ public class InstrumentQueryService {
 			.map(BassGuitarDto::from);
 	}
 
-	public Page<AcousticAndClassicGuitarDto> findAcousticAndClassicGuitars(
+	public Page<AcousticAndClassicGuitarDto> findAcousticAndClassicGuitarDtos(
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
@@ -69,7 +69,7 @@ public class InstrumentQueryService {
 			.map(AcousticAndClassicGuitarDto::from);
 	}
 
-	public Page<EffectorDto> findEffectors(
+	public Page<EffectorDto> findEffectorDtos(
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
@@ -80,7 +80,7 @@ public class InstrumentQueryService {
 			.map(EffectorDto::from);
 	}
 
-	public Page<AmplifierDto> findAmplifiers(
+	public Page<AmplifierDto> findAmplifierDtos(
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,
@@ -91,7 +91,7 @@ public class InstrumentQueryService {
 			.map(AmplifierDto::from);
 	}
 
-	public Page<AudioEquipmentDto> findAudioEquipments(
+	public Page<AudioEquipmentDto> findAudioEquipmentDtos(
 		int page,
 		int pageSize,
 		InstrumentSortOption sort,

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -19,12 +19,6 @@ import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditio
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
-import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
-import com.ajou.hertz.domain.instrument.entity.Amplifier;
-import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
-import com.ajou.hertz.domain.instrument.entity.BassGuitar;
-import com.ajou.hertz.domain.instrument.entity.Effector;
-import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.ajou.hertz.domain.instrument.exception.InstrumentNotFoundByIdException;
 import com.ajou.hertz.domain.instrument.mapper.InstrumentMapper;
@@ -47,7 +41,7 @@ public class InstrumentQueryService {
 	public Page<InstrumentDto> findInstrumentDtos(int page, int pageSize, InstrumentSortOption sort) {
 		return instrumentRepository
 			.findAll(PageRequest.of(page, pageSize, sort.toSort()))
-			.map(InstrumentDto::from);
+			.map(InstrumentMapper::toDto);
 	}
 
 	public Page<ElectricGuitarDto> findElectricGuitarDtos(
@@ -58,7 +52,7 @@ public class InstrumentQueryService {
 	) {
 		return instrumentRepository
 			.findElectricGuitars(page, pageSize, sort, filterConditions)
-			.map(ElectricGuitarDto::from);
+			.map(InstrumentMapper::toElectricGuitarDto);
 	}
 
 	public Page<BassGuitarDto> findBassGuitarDtos(
@@ -69,7 +63,7 @@ public class InstrumentQueryService {
 	) {
 		return instrumentRepository
 			.findBassGuitars(page, pageSize, sort, filterConditions)
-			.map(BassGuitarDto::from);
+			.map(InstrumentMapper::toBassGuitarDto);
 	}
 
 	public Page<AcousticAndClassicGuitarDto> findAcousticAndClassicGuitarDtos(
@@ -80,7 +74,7 @@ public class InstrumentQueryService {
 	) {
 		return instrumentRepository
 			.findAcousticAndClassicGuitars(page, pageSize, sort, filterConditions)
-			.map(AcousticAndClassicGuitarDto::from);
+			.map(InstrumentMapper::toAcousticAndClassicGuitarDto);
 	}
 
 	public Page<EffectorDto> findEffectorDtos(
@@ -91,7 +85,7 @@ public class InstrumentQueryService {
 	) {
 		return instrumentRepository
 			.findEffectors(page, pageSize, sort, filterConditions)
-			.map(EffectorDto::from);
+			.map(InstrumentMapper::toEffectorDto);
 	}
 
 	public Page<AmplifierDto> findAmplifierDtos(
@@ -102,7 +96,7 @@ public class InstrumentQueryService {
 	) {
 		return instrumentRepository
 			.findAmplifiers(page, pageSize, sort, filterConditions)
-			.map(AmplifierDto::from);
+			.map(InstrumentMapper::toAmplifierDto);
 	}
 
 	public Page<AudioEquipmentDto> findAudioEquipmentDtos(
@@ -113,7 +107,7 @@ public class InstrumentQueryService {
 	) {
 		return instrumentRepository
 			.findAudioEquipments(page, pageSize, sort, filterConditions)
-			.map(AudioEquipmentDto::from);
+			.map(InstrumentMapper::toAmplifierDto);
 	}
 
 	private Instrument getInstrumentById(Long id) {

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -19,6 +19,15 @@ import com.ajou.hertz.domain.instrument.dto.request.AudioEquipmentFilterConditio
 import com.ajou.hertz.domain.instrument.dto.request.BassGuitarFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.EffectorFilterConditions;
 import com.ajou.hertz.domain.instrument.dto.request.ElectricGuitarFilterConditions;
+import com.ajou.hertz.domain.instrument.entity.AcousticAndClassicGuitar;
+import com.ajou.hertz.domain.instrument.entity.Amplifier;
+import com.ajou.hertz.domain.instrument.entity.AudioEquipment;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.Effector;
+import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.instrument.exception.InstrumentNotFoundByIdException;
+import com.ajou.hertz.domain.instrument.mapper.InstrumentMapper;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -29,6 +38,11 @@ import lombok.RequiredArgsConstructor;
 public class InstrumentQueryService {
 
 	private final InstrumentRepository instrumentRepository;
+
+	public InstrumentDto getInstrumentDtoById(Long id) {
+		Instrument instrument = getInstrumentById(id);
+		return InstrumentMapper.toDto(instrument);
+	}
 
 	public Page<InstrumentDto> findInstrumentDtos(int page, int pageSize, InstrumentSortOption sort) {
 		return instrumentRepository
@@ -100,5 +114,10 @@ public class InstrumentQueryService {
 		return instrumentRepository
 			.findAudioEquipments(page, pageSize, sort, filterConditions)
 			.map(AudioEquipmentDto::from);
+	}
+
+	private Instrument getInstrumentById(Long id) {
+		return instrumentRepository.findById(id)
+			.orElseThrow(() -> new InstrumentNotFoundByIdException(id));
 	}
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,6 @@ hertz.user-default-profile-image-url=${USER_DEFAULT_PROFILE_IMAGE}
 jwt.secret-key=${JWT_SECRET_KEY}
 
 springdoc.swagger-ui.operations-sorter=method
-springdoc.use-fqn=true
 
 logging.level.com.ajou.hertz=info
 logging.level.org.hibernate.SQL=info

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -96,6 +96,26 @@ class InstrumentControllerTest {
 	}
 
 	@Test
+	void id가_주어지고_id에_해당하는_악기를_조회한다() throws Exception {
+		// given
+		long instrumentId = 1L;
+		InstrumentDto expectedResult = createAmplifierDto(instrumentId, 2L);
+		given(instrumentQueryService.getInstrumentDtoById(instrumentId)).willReturn(expectedResult);
+
+		// when & then
+		mvc.perform(
+				get("/api/instruments/{instrumentId}", instrumentId)
+					.header(API_VERSION_HEADER_NAME, 1)
+			)
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(expectedResult.getId()))
+			.andExpect(jsonPath("$.sellerId").value(expectedResult.getSeller().getId()))
+			.andExpect(jsonPath("$.category").value(expectedResult.getCategory().name()));
+		then(instrumentQueryService).should().getInstrumentDtoById(instrumentId);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
+	@Test
 	void 종류_상관_없이_전체_악기_매물_목록을_조회한다() throws Exception {
 		// given
 		long userId = 1L;

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -107,7 +107,7 @@ class InstrumentControllerTest {
 			createBassGuitarDto(3L, userId),
 			createAcousticAndClassicGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findInstruments(page, pageSize, sortOption)).willReturn(expectedResult);
+		given(instrumentQueryService.findInstrumentDtos(page, pageSize, sortOption)).willReturn(expectedResult);
 
 		// when & then
 		mvc.perform(
@@ -127,7 +127,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content[0].category").value(InstrumentCategory.ELECTRIC_GUITAR.name()))
 			.andExpect(jsonPath("$.content[1].category").value(InstrumentCategory.BASS_GUITAR.name()))
 			.andExpect(jsonPath("$.content[2].category").value(InstrumentCategory.ACOUSTIC_AND_CLASSIC_GUITAR.name()));
-		then(instrumentQueryService).should().findInstruments(page, pageSize, sortOption);
+		then(instrumentQueryService).should().findInstrumentDtos(page, pageSize, sortOption);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -143,7 +143,7 @@ class InstrumentControllerTest {
 			createElectricGuitarDto(3L, userId),
 			createElectricGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findElectricGuitars(
+		given(instrumentQueryService.findElectricGuitarDtos(
 			eq(page), eq(pageSize), eq(sortOption), any(ElectricGuitarFilterConditions.class)
 		)).willReturn(expectedResult);
 
@@ -167,7 +167,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findElectricGuitars(eq(page), eq(pageSize), eq(sortOption), any(ElectricGuitarFilterConditions.class));
+			.findElectricGuitarDtos(eq(page), eq(pageSize), eq(sortOption), any(ElectricGuitarFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -184,7 +184,7 @@ class InstrumentControllerTest {
 			createBassGuitarDto(3L, userId),
 			createBassGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findBassGuitars(
+		given(instrumentQueryService.findBassGuitarDtos(
 			eq(page), eq(pageSize), eq(sortOption), any(BassGuitarFilterConditions.class)
 		)).willReturn(expectedResult);
 
@@ -209,7 +209,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findBassGuitars(eq(page), eq(pageSize), eq(sortOption), any(BassGuitarFilterConditions.class));
+			.findBassGuitarDtos(eq(page), eq(pageSize), eq(sortOption), any(BassGuitarFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -226,7 +226,7 @@ class InstrumentControllerTest {
 			createAcousticAndClassicGuitarDto(3L, userId),
 			createAcousticAndClassicGuitarDto(4L, userId)
 		));
-		given(instrumentQueryService.findAcousticAndClassicGuitars(
+		given(instrumentQueryService.findAcousticAndClassicGuitarDtos(
 			eq(page), eq(pageSize), eq(sortOption), any(AcousticAndClassicGuitarFilterConditions.class)
 		)).willReturn(expectedResult);
 
@@ -251,7 +251,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findAcousticAndClassicGuitars(
+			.findAcousticAndClassicGuitarDtos(
 				eq(page), eq(pageSize), eq(sortOption), any(AcousticAndClassicGuitarFilterConditions.class)
 			);
 		verifyEveryMocksShouldHaveNoMoreInteractions();
@@ -270,7 +270,7 @@ class InstrumentControllerTest {
 			createEffectorDto(3L, userId),
 			createEffectorDto(4L, userId)
 		));
-		given(instrumentQueryService.findEffectors(
+		given(instrumentQueryService.findEffectorDtos(
 			eq(page), eq(pageSize), eq(sortOption), any(EffectorFilterConditions.class)
 		)).willReturn(expectedResult);
 
@@ -293,7 +293,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findEffectors(eq(page), eq(pageSize), eq(sortOption), any(EffectorFilterConditions.class));
+			.findEffectorDtos(eq(page), eq(pageSize), eq(sortOption), any(EffectorFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -310,7 +310,7 @@ class InstrumentControllerTest {
 			createAmplifierDto(3L, userId),
 			createAmplifierDto(4L, userId)
 		));
-		given(instrumentQueryService.findAmplifiers(
+		given(instrumentQueryService.findAmplifierDtos(
 			eq(page), eq(pageSize), eq(sortOption), any(AmplifierFilterConditions.class)
 		)).willReturn(expectedResult);
 
@@ -334,7 +334,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findAmplifiers(eq(page), eq(pageSize), eq(sortOption), any(AmplifierFilterConditions.class));
+			.findAmplifierDtos(eq(page), eq(pageSize), eq(sortOption), any(AmplifierFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
@@ -351,7 +351,7 @@ class InstrumentControllerTest {
 			createAudioEquipmentDto(3L, userId),
 			createAudioEquipmentDto(4L, userId)
 		));
-		given(instrumentQueryService.findAudioEquipments(
+		given(instrumentQueryService.findAudioEquipmentDtos(
 			eq(page), eq(pageSize), eq(sortOption), any(AudioEquipmentFilterConditions.class)
 		)).willReturn(expectedResult);
 
@@ -373,7 +373,7 @@ class InstrumentControllerTest {
 			.andExpect(jsonPath("$.content", hasSize(expectedResult.getNumberOfElements())));
 		then(instrumentQueryService)
 			.should()
-			.findAudioEquipments(eq(page), eq(pageSize), eq(sortOption), any(AudioEquipmentFilterConditions.class));
+			.findAudioEquipmentDtos(eq(page), eq(pageSize), eq(sortOption), any(AudioEquipmentFilterConditions.class));
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -90,7 +90,7 @@ class InstrumentQueryServiceTest {
 		given(instrumentRepository.findAll(any(Pageable.class))).willReturn(expectedResult);
 
 		// when
-		Page<InstrumentDto> actualResult = sut.findInstruments(page, pageSize, sort);
+		Page<InstrumentDto> actualResult = sut.findInstrumentDtos(page, pageSize, sort);
 
 		// then
 		then(instrumentRepository).should().findAll(any(Pageable.class));
@@ -137,7 +137,7 @@ class InstrumentQueryServiceTest {
 			.willReturn(expectedResult);
 
 		// when
-		Page<ElectricGuitarDto> actualResult = sut.findElectricGuitars(page, pageSize, sort, filterConditions);
+		Page<ElectricGuitarDto> actualResult = sut.findElectricGuitarDtos(page, pageSize, sort, filterConditions);
 
 		// then
 		then(instrumentRepository).should().findElectricGuitars(page, pageSize, sort, filterConditions);
@@ -165,7 +165,7 @@ class InstrumentQueryServiceTest {
 		given(instrumentRepository.findBassGuitars(page, pageSize, sort, filterConditions)).willReturn(expectedResult);
 
 		// when
-		Page<BassGuitarDto> actualResult = sut.findBassGuitars(page, pageSize, sort, filterConditions);
+		Page<BassGuitarDto> actualResult = sut.findBassGuitarDtos(page, pageSize, sort, filterConditions);
 
 		// then
 		then(instrumentRepository).should().findBassGuitars(page, pageSize, sort, filterConditions);
@@ -196,7 +196,7 @@ class InstrumentQueryServiceTest {
 
 		// when
 		Page<AcousticAndClassicGuitarDto> actualResult =
-			sut.findAcousticAndClassicGuitars(page, pageSize, sort, filterConditions);
+			sut.findAcousticAndClassicGuitarDtos(page, pageSize, sort, filterConditions);
 
 		// then
 		then(instrumentRepository).should().findAcousticAndClassicGuitars(page, pageSize, sort, filterConditions);
@@ -224,7 +224,7 @@ class InstrumentQueryServiceTest {
 		given(instrumentRepository.findEffectors(page, pageSize, sort, filterConditions)).willReturn(expectedResult);
 
 		// when
-		Page<EffectorDto> actualResult = sut.findEffectors(page, pageSize, sort, filterConditions);
+		Page<EffectorDto> actualResult = sut.findEffectorDtos(page, pageSize, sort, filterConditions);
 
 		// then
 		then(instrumentRepository).should().findEffectors(page, pageSize, sort, filterConditions);
@@ -252,7 +252,7 @@ class InstrumentQueryServiceTest {
 		given(instrumentRepository.findAmplifiers(page, pageSize, sort, filterConditions)).willReturn(expectedResult);
 
 		// when
-		Page<AmplifierDto> actualResult = sut.findAmplifiers(page, pageSize, sort, filterConditions);
+		Page<AmplifierDto> actualResult = sut.findAmplifierDtos(page, pageSize, sort, filterConditions);
 
 		// then
 		then(instrumentRepository).should().findAmplifiers(page, pageSize, sort, filterConditions);
@@ -281,7 +281,7 @@ class InstrumentQueryServiceTest {
 			.willReturn(expectedResult);
 
 		// when
-		Page<AudioEquipmentDto> actualResult = sut.findAudioEquipments(page, pageSize, sort, filterConditions);
+		Page<AudioEquipmentDto> actualResult = sut.findAudioEquipmentDtos(page, pageSize, sort, filterConditions);
 
 		// then
 		then(instrumentRepository).should().findAudioEquipments(page, pageSize, sort, filterConditions);

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
@@ -58,6 +59,7 @@ import com.ajou.hertz.domain.instrument.entity.BassGuitar;
 import com.ajou.hertz.domain.instrument.entity.Effector;
 import com.ajou.hertz.domain.instrument.entity.ElectricGuitar;
 import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.instrument.exception.InstrumentNotFoundByIdException;
 import com.ajou.hertz.domain.instrument.repository.InstrumentRepository;
 import com.ajou.hertz.domain.instrument.service.InstrumentQueryService;
 import com.ajou.hertz.domain.user.constant.Gender;
@@ -74,6 +76,39 @@ class InstrumentQueryServiceTest {
 
 	@Mock
 	private InstrumentRepository instrumentRepository;
+
+	@Test
+	void id가_주어지고_주어진_id에_해당하는_악기를_조회한다() throws Exception {
+		// given
+		long instrumentId = 1L;
+		Instrument expectedResult = createAmplifier(instrumentId, createUser(2L));
+		given(instrumentRepository.findById(instrumentId)).willReturn(Optional.of(expectedResult));
+
+		// when
+		InstrumentDto actualResult = sut.getInstrumentDtoById(instrumentId);
+
+		// then
+		then(instrumentRepository).should().findById(instrumentId);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult)
+			.hasFieldOrPropertyWithValue("id", expectedResult.getId())
+			.hasFieldOrPropertyWithValue("category", InstrumentCategory.AMPLIFIER);
+	}
+
+	@Test
+	void 존재하지_않은_id가_주어지고_id에_해당하는_악기를_조회하면_예외가_발생한다() throws Exception {
+		// given
+		long instrumentId = 1L;
+		given(instrumentRepository.findById(instrumentId)).willReturn(Optional.empty());
+
+		// when
+		Throwable t = catchThrowable(() -> sut.getInstrumentDtoById(instrumentId));
+
+		// then
+		then(instrumentRepository).should().findById(instrumentId);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(t).isInstanceOf(InstrumentNotFoundByIdException.class);
+	}
 
 	@Test
 	void 종류_상관_없이_전체_악기_목록을_조회한다() throws Exception {


### PR DESCRIPTION
## 🔥 Related Issue
- Close #79

## 🏃‍ Task
- 악기 매물 상세 조회 API 구현
- `InstrumentMapper` 생성 및 악기 DTO, entity 변환 로직을 `InstrumentMapper`가 수행하도록 refactoring
- Swagger 설정 변경 (Show FQN 해제)

## 📄 Reference
- None
