### PR TITLE
악기 매물 삭제 API 구현

### DIFF
--- a/src/main/java/com/ajou/hertz/common/exception/constant/CustomExceptionType.java
+++ b/src/main/java/com/ajou/hertz/common/exception/constant/CustomExceptionType.java
@@ -51,8 +51,8 @@ public enum CustomExceptionType {
 	/**
 	 * 악기 관련 예외
 	 */
-	INSTRUMENT_NOT_FOUND_BY_ID(2600, "일치하는 매물 정보를 찾을 수 없습니다.")
-	;
+	INSTRUMENT_NOT_FOUND_BY_ID(2600, "일치하는 매물 정보를 찾을 수 없습니다."),
+	INSTRUMENT_DELETE_PERMISSION_DENIED(2601, "악기 매물을 삭제할 권한이 없습니다. 매물은 판매자 본인만 삭제할 수 있습니다.");
 
 	private final Integer code;
 	private final String message;

--- a/src/main/java/com/ajou/hertz/common/file/service/FileService.java
+++ b/src/main/java/com/ajou/hertz/common/file/service/FileService.java
@@ -1,5 +1,6 @@
 package com.ajou.hertz.common.file.service;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
@@ -24,5 +25,12 @@ public interface FileService {
 	 * @param uploadPath    파일들을 업로드할 경로
 	 * @return 저장된 파일들의 정보가 담긴 dto list
 	 */
-	List<FileDto> uploadFiles(List<MultipartFile> multipartFiles, String uploadPath);
+	List<FileDto> uploadFiles(Iterable<MultipartFile> multipartFiles, String uploadPath);
+
+	/**
+	 * 파일들을 삭제한다.
+	 *
+	 * @param storedFileNames 삭제할 파일들의 이름 목록
+	 */
+	void deleteAll(Collection<String> storedFileNames);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/controller/InstrumentController.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -52,6 +53,9 @@ import com.ajou.hertz.domain.instrument.service.InstrumentQueryService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -410,5 +414,23 @@ public class InstrumentController {
 		return ResponseEntity
 			.created(URI.create("/instruments/" + audioEquipment.getId()))
 			.body(InstrumentMapper.toAudioEquipmentResponse(audioEquipment));
+	}
+
+	@Operation(
+		summary = "악기 매물 삭제",
+		description = "악기 매물을 삭제합니다. 매물 삭제는 판매자만 할 수 있습니다.",
+		security = @SecurityRequirement(name = "access-token")
+	)
+	@ApiResponses({
+		@ApiResponse(responseCode = "204"),
+		@ApiResponse(responseCode = "403", description = "[2601] 악기를 삭제하려는 유저가 판매자가 아닌 경우", content = @Content)
+	})
+	@DeleteMapping(value = "/{instrumentId}", headers = API_VERSION_HEADER_NAME + "=" + 1)
+	public ResponseEntity<Void> deleteInstrumentV1(
+		@AuthenticationPrincipal UserPrincipal userPrincipal,
+		@Parameter(description = "Id of instrument", example = "2") @PathVariable Long instrumentId
+	) {
+		instrumentCommandService.deleteInstrumentById(userPrincipal.getUserId(), instrumentId);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/exception/InstrumentDeletePermissionDeniedException.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/exception/InstrumentDeletePermissionDeniedException.java
@@ -1,0 +1,11 @@
+package com.ajou.hertz.domain.instrument.exception;
+
+import com.ajou.hertz.common.exception.ForbiddenException;
+import com.ajou.hertz.common.exception.constant.CustomExceptionType;
+
+public class InstrumentDeletePermissionDeniedException extends ForbiddenException {
+
+	public InstrumentDeletePermissionDeniedException() {
+		super(CustomExceptionType.INSTRUMENT_DELETE_PERMISSION_DENIED);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentHashtagRepository.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentHashtagRepository.java
@@ -2,7 +2,10 @@ package com.ajou.hertz.domain.instrument.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.ajou.hertz.domain.instrument.entity.Instrument;
 import com.ajou.hertz.domain.instrument.entity.InstrumentHashtag;
 
 public interface InstrumentHashtagRepository extends JpaRepository<InstrumentHashtag, Long> {
+
+	void deleteAllByInstrument(Instrument instrument);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentImageRepository.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/repository/InstrumentImageRepository.java
@@ -1,8 +1,12 @@
 package com.ajou.hertz.domain.instrument.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.ajou.hertz.domain.instrument.entity.InstrumentImage;
 
 public interface InstrumentImageRepository extends JpaRepository<InstrumentImage, Long> {
+
+	List<InstrumentImage> findAllByInstrument_Id(Long instrumentId);
 }

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentImageCommandService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentImageCommandService.java
@@ -1,0 +1,61 @@
+package com.ajou.hertz.domain.instrument.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ajou.hertz.common.file.service.FileService;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.instrument.entity.InstrumentImage;
+import com.ajou.hertz.domain.instrument.repository.InstrumentImageRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class InstrumentImageCommandService {
+
+	private static final String INSTRUMENT_IMAGE_UPLOAD_PATH = "instrument-image/";
+
+	private final InstrumentImageQueryService instrumentImageQueryService;
+	private final FileService fileService;
+	private final InstrumentImageRepository instrumentImageRepository;
+
+	/**
+	 * 전달받은 multipart files로 instrument image entity를 생성 후 저장한다.
+	 *
+	 * @param instrument 이미지의 대상이 되는 instrument entity
+	 * @param images 저장하고자 하는 image
+	 * @return 저장된 instrument images
+	 */
+	public List<InstrumentImage> saveImages(Instrument instrument, Iterable<MultipartFile> images) {
+		List<InstrumentImage> instrumentImages = fileService
+			.uploadFiles(images, INSTRUMENT_IMAGE_UPLOAD_PATH)
+			.stream()
+			.map(fileDto -> InstrumentImage.create(
+				instrument,
+				fileDto.getOriginalName(),
+				fileDto.getStoredName(),
+				fileDto.getUrl()
+			)).toList();
+		return instrumentImageRepository.saveAll(instrumentImages);
+	}
+
+	/**
+	 * 특정 악기 매물의 모든 이미지를 삭제한다.
+	 *
+	 * @param instrumentId    이미지를 전체 삭제할 악기 매물의 id
+	 */
+	public void deleteAllByInstrumentId(Long instrumentId) {
+		List<InstrumentImage> instrumentImages = instrumentImageQueryService.findAllByInstrumentId(instrumentId);
+		fileService.deleteAll(
+			instrumentImages.stream()
+				.map(InstrumentImage::getStoredName)
+				.toList()
+		);
+		instrumentImageRepository.deleteAll(instrumentImages);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentImageQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentImageQueryService.java
@@ -1,0 +1,29 @@
+package com.ajou.hertz.domain.instrument.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ajou.hertz.domain.instrument.entity.InstrumentImage;
+import com.ajou.hertz.domain.instrument.repository.InstrumentImageRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class InstrumentImageQueryService {
+
+	private final InstrumentImageRepository instrumentImageRepository;
+
+	/**
+	 * 악기 id를 전달받고, 해당하는 악기의 이미지를 전부 조회한다.
+	 *
+	 * @param instrumentId 이미지를 조회하고자 하는 악기의 id
+	 * @return 조회된 Instrument image entity list
+	 */
+	public List<InstrumentImage> findAllByInstrumentId(Long instrumentId) {
+		return instrumentImageRepository.findAllByInstrument_Id(instrumentId);
+	}
+}

--- a/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
+++ b/src/main/java/com/ajou/hertz/domain/instrument/service/InstrumentQueryService.java
@@ -33,17 +33,50 @@ public class InstrumentQueryService {
 
 	private final InstrumentRepository instrumentRepository;
 
+	/**
+	 * Id로 악기를 조회한다.
+	 *
+	 * @param id 조회하고자 하는 Instrument entity의 id
+	 * @return 조회된 Instrument entity
+	 */
+	public Instrument getInstrumentById(Long id) {
+		return instrumentRepository.findById(id)
+			.orElseThrow(() -> new InstrumentNotFoundByIdException(id));
+	}
+
+	/**
+	 * Id로 악기를 조회한다.
+	 *
+	 * @param id 조회하고자 하는 악기의 id
+	 * @return 조회된 Instrument dto
+	 */
 	public InstrumentDto getInstrumentDtoById(Long id) {
 		Instrument instrument = getInstrumentById(id);
 		return InstrumentMapper.toDto(instrument);
 	}
 
+	/**
+	 * 악기 목록을 조회한다.
+	 *
+	 * @param page     페이지 번호
+	 * @param pageSize 페이지 크기
+	 * @param sort     정렬 기준
+	 * @return 조회된 악기 dto 목록
+	 */
 	public Page<InstrumentDto> findInstrumentDtos(int page, int pageSize, InstrumentSortOption sort) {
 		return instrumentRepository
 			.findAll(PageRequest.of(page, pageSize, sort.toSort()))
 			.map(InstrumentMapper::toDto);
 	}
 
+	/**
+	 * 일렉 기타 목록을 조회한다.
+	 *
+	 * @param page     페이지 번호
+	 * @param pageSize 페이지 크기
+	 * @param sort     정렬 기준
+	 * @return 조회된 일렉 기타 dto 목록
+	 */
 	public Page<ElectricGuitarDto> findElectricGuitarDtos(
 		int page,
 		int pageSize,
@@ -55,6 +88,14 @@ public class InstrumentQueryService {
 			.map(InstrumentMapper::toElectricGuitarDto);
 	}
 
+	/**
+	 * 베이스 기타 목록을 조회한다.
+	 *
+	 * @param page     페이지 번호
+	 * @param pageSize 페이지 크기
+	 * @param sort     정렬 기준
+	 * @return 조회된 베이스 기타 dto 목록
+	 */
 	public Page<BassGuitarDto> findBassGuitarDtos(
 		int page,
 		int pageSize,
@@ -66,6 +107,14 @@ public class InstrumentQueryService {
 			.map(InstrumentMapper::toBassGuitarDto);
 	}
 
+	/**
+	 * 어쿠스틱&클래식 기타 목록을 조회한다.
+	 *
+	 * @param page     페이지 번호
+	 * @param pageSize 페이지 크기
+	 * @param sort     정렬 기준
+	 * @return 조회된 어쿠스틱&클래식 기타 dto 목록
+	 */
 	public Page<AcousticAndClassicGuitarDto> findAcousticAndClassicGuitarDtos(
 		int page,
 		int pageSize,
@@ -77,6 +126,14 @@ public class InstrumentQueryService {
 			.map(InstrumentMapper::toAcousticAndClassicGuitarDto);
 	}
 
+	/**
+	 * 이펙터 목록을 조회한다.
+	 *
+	 * @param page     페이지 번호
+	 * @param pageSize 페이지 크기
+	 * @param sort     정렬 기준
+	 * @return 조회된 이펙터 dto 목록
+	 */
 	public Page<EffectorDto> findEffectorDtos(
 		int page,
 		int pageSize,
@@ -88,6 +145,14 @@ public class InstrumentQueryService {
 			.map(InstrumentMapper::toEffectorDto);
 	}
 
+	/**
+	 * 앰프 목록을 조회한다.
+	 *
+	 * @param page     페이지 번호
+	 * @param pageSize 페이지 크기
+	 * @param sort     정렬 기준
+	 * @return 조회된 앰프 dto 목록
+	 */
 	public Page<AmplifierDto> findAmplifierDtos(
 		int page,
 		int pageSize,
@@ -99,6 +164,14 @@ public class InstrumentQueryService {
 			.map(InstrumentMapper::toAmplifierDto);
 	}
 
+	/**
+	 * 음향 장비 목록을 조회한다.
+	 *
+	 * @param page     페이지 번호
+	 * @param pageSize 페이지 크기
+	 * @param sort     정렬 기준
+	 * @return 조회된 음향 장비 dto 목록
+	 */
 	public Page<AudioEquipmentDto> findAudioEquipmentDtos(
 		int page,
 		int pageSize,
@@ -108,10 +181,5 @@ public class InstrumentQueryService {
 		return instrumentRepository
 			.findAudioEquipments(page, pageSize, sort, filterConditions)
 			.map(InstrumentMapper::toAmplifierDto);
-	}
-
-	private Instrument getInstrumentById(Long id) {
-		return instrumentRepository.findById(id)
-			.orElseThrow(() -> new InstrumentNotFoundByIdException(id));
 	}
 }

--- a/src/test/java/com/ajou/hertz/unit/common/file/service/AmazonS3FileServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/common/file/service/AmazonS3FileServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.*;
 import java.io.IOException;
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,6 +23,7 @@ import com.ajou.hertz.common.file.dto.FileDto;
 import com.ajou.hertz.common.file.service.AmazonS3FileService;
 import com.ajou.hertz.common.properties.AWSProperties;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
 
@@ -42,17 +44,17 @@ class AmazonS3FileServiceTest {
 	@Mock
 	private AWSProperties.CloudFront cloudFront;
 
-	private void setUpMockProperties() {
-		given(awsProperties.s3()).willReturn(s3);
-		given(awsProperties.cloudFront()).willReturn(cloudFront);
-		given(awsProperties.s3().bucketName()).willReturn("aws-s3-bucket-name");
-		given(awsProperties.cloudFront().baseUrl()).willReturn("aws-cloud-front-base-url/");
+	@BeforeEach
+	void setUpMockProperties() {
+		lenient().when(awsProperties.s3()).thenReturn(s3);
+		lenient().when(awsProperties.cloudFront()).thenReturn(cloudFront);
+		lenient().when(awsProperties.s3().bucketName()).thenReturn("aws-s3-bucket-name");
+		lenient().when(awsProperties.cloudFront().baseUrl()).thenReturn("aws-cloud-front-base-url/");
 	}
 
 	@Test
 	void 파일이_주어지면_파일을_S3에_업로드한다() {
 		// given
-		setUpMockProperties();
 		MultipartFile multipartFile = createMockMultipartFile(null);
 		given(s3Client.putObject(any(PutObjectRequest.class))).willReturn(new PutObjectResult());
 
@@ -61,7 +63,7 @@ class AmazonS3FileServiceTest {
 
 		// then
 		then(s3Client).should().putObject(any(PutObjectRequest.class));
-		then(s3Client).shouldHaveNoMoreInteractions();
+		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
 	@Test
@@ -75,13 +77,12 @@ class AmazonS3FileServiceTest {
 
 		// then
 		assertThat(t).isInstanceOf(MultipartFileNotReadableException.class);
-		then(s3Client).shouldHaveNoInteractions();
+		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
 	@Test
 	void 여러_개의_파일들이_주어지면_전부_S3에_업로드한다() {
 		// given
-		setUpMockProperties();
 		List<MultipartFile> multipartFiles = List.of(
 			createMockMultipartFile("1"),
 			createMockMultipartFile("2"),
@@ -94,13 +95,36 @@ class AmazonS3FileServiceTest {
 
 		// then
 		verify(s3Client, times(multipartFiles.size())).putObject(any(PutObjectRequest.class));
-		then(s3Client).shouldHaveNoMoreInteractions();
+		verifyEveryMocksShouldHaveNoMoreInteractions();
 		assertThat(results.size()).isEqualTo(multipartFiles.size());
 		for (int i = 0; i < results.size(); i++) {
 			MultipartFile multipartFile = multipartFiles.get(i);
 			FileDto result = results.get(i);
 			assertThat(result.getOriginalName()).isEqualTo(multipartFile.getOriginalFilename());
 		}
+	}
+
+	@Test
+	void S3에_저장된_파일들의_이름이_주어지고_파일들을_S3_버킷에서_삭제한다() throws Exception {
+		// given
+		List<String> storedFileNames = List.of(
+			"stored-file-name-1",
+			"stored-file-name-2",
+			"stored-file-name-3",
+			"stored-file-name-4"
+		);
+		willDoNothing().given(s3Client).deleteObject(any(DeleteObjectRequest.class));
+
+		// when
+		sut.deleteAll(storedFileNames);
+
+		// then
+		verify(s3Client, times(storedFileNames.size())).deleteObject(any(DeleteObjectRequest.class));
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
+	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
+		then(s3Client).shouldHaveNoMoreInteractions();
 	}
 
 	private MockMultipartFile createMockMultipartFile(String fileName) {

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/controller/InstrumentControllerTest.java
@@ -663,6 +663,24 @@ class InstrumentControllerTest {
 		verifyEveryMocksShouldHaveNoMoreInteractions();
 	}
 
+	@Test
+	void 악기_id가_주어지고_해당하는_악기_매물을_삭제한다() throws Exception {
+		// given
+		long userId = 1L;
+		long instrumentId = 2L;
+		willDoNothing().given(instrumentCommandService).deleteInstrumentById(userId, instrumentId);
+
+		// when & then
+		mvc.perform(
+				delete("/api/instruments/{instrumentId}", instrumentId)
+					.header(API_VERSION_HEADER_NAME, 1)
+					.with(user(createTestUser(userId)))
+			)
+			.andExpect(status().isNoContent());
+		then(instrumentCommandService).should().deleteInstrumentById(userId, instrumentId);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
 	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
 		then(instrumentCommandService).shouldHaveNoMoreInteractions();
 		then(instrumentQueryService).shouldHaveNoMoreInteractions();

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentImageCommandServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentImageCommandServiceTest.java
@@ -1,0 +1,178 @@
+package com.ajou.hertz.unit.domain.instrument.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.ajou.hertz.common.entity.Address;
+import com.ajou.hertz.common.file.dto.FileDto;
+import com.ajou.hertz.common.file.service.FileService;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.GuitarColor;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.instrument.entity.InstrumentImage;
+import com.ajou.hertz.domain.instrument.repository.InstrumentImageRepository;
+import com.ajou.hertz.domain.instrument.service.InstrumentImageCommandService;
+import com.ajou.hertz.domain.instrument.service.InstrumentImageQueryService;
+import com.ajou.hertz.domain.user.constant.Gender;
+import com.ajou.hertz.domain.user.constant.RoleType;
+import com.ajou.hertz.domain.user.entity.User;
+import com.ajou.hertz.util.ReflectionUtils;
+
+@DisplayName("[Unit] Service(Command) - Instrument Image")
+@ExtendWith(MockitoExtension.class)
+class InstrumentImageCommandServiceTest {
+
+	@InjectMocks
+	private InstrumentImageCommandService sut;
+
+	@Mock
+	private InstrumentImageQueryService instrumentImageQueryService;
+
+	@Mock
+	private FileService fileService;
+
+	@Mock
+	private InstrumentImageRepository instrumentImageRepository;
+
+	@Test
+	void 악기와_이미지_파일들이_주어지고_이미지_파일들을_업로드_한_후_주어진_악기에_대한_이미지_entities를_생성한다() throws Exception {
+		// given
+		List<MultipartFile> images = List.of(
+			createMultipartFile(),
+			createMultipartFile(),
+			createMultipartFile(),
+			createMultipartFile()
+		);
+		BassGuitar bassGuitar = createBassGuitar(1L, createUser(2L));
+		List<InstrumentImage> expectedResult = List.of(
+			createInstrumentImage(3L, bassGuitar),
+			createInstrumentImage(4L, bassGuitar),
+			createInstrumentImage(5L, bassGuitar),
+			createInstrumentImage(6L, bassGuitar)
+		);
+		given(fileService.uploadFiles(ArgumentMatchers.<List<MultipartFile>>any(), anyString()))
+			.willReturn(List.of(createFileDto(), createFileDto(), createFileDto(), createFileDto()));
+		given(instrumentImageRepository.saveAll(ArgumentMatchers.<List<InstrumentImage>>any()))
+			.willReturn(expectedResult);
+
+		// when
+		List<InstrumentImage> actualResult = sut.saveImages(bassGuitar, images);
+
+		// then
+		then(fileService).should().uploadFiles(ArgumentMatchers.<List<MultipartFile>>any(), anyString());
+		then(instrumentImageRepository).should().saveAll(ArgumentMatchers.<List<InstrumentImage>>any());
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult.size()).isEqualTo(expectedResult.size());
+	}
+
+	@Test
+	void 악기_id가_주어지고_악기의_이미지를_전부_삭제한다() throws Exception {
+		// given
+		long instrumentId = 1L;
+		BassGuitar bassGuitar = createBassGuitar(instrumentId, createUser(2L));
+		List<InstrumentImage> instrumentImagesToDelete = List.of(
+			createInstrumentImage(2L, bassGuitar),
+			createInstrumentImage(3L, bassGuitar),
+			createInstrumentImage(4L, bassGuitar),
+			createInstrumentImage(5L, bassGuitar)
+		);
+		List<String> storedImageNames = instrumentImagesToDelete.stream().map(InstrumentImage::getStoredName).toList();
+		given(instrumentImageQueryService.findAllByInstrumentId(instrumentId)).willReturn(instrumentImagesToDelete);
+		willDoNothing().given(fileService).deleteAll(storedImageNames);
+		willDoNothing().given(instrumentImageRepository).deleteAll(instrumentImagesToDelete);
+
+		// when
+		sut.deleteAllByInstrumentId(instrumentId);
+
+		// then
+		then(instrumentImageQueryService).should().findAllByInstrumentId(instrumentId);
+		then(fileService).should().deleteAll(storedImageNames);
+		then(instrumentImageRepository).should().deleteAll(instrumentImagesToDelete);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+	}
+
+	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
+		then(instrumentImageQueryService).shouldHaveNoMoreInteractions();
+		then(fileService).shouldHaveNoMoreInteractions();
+		then(instrumentImageRepository).shouldHaveNoMoreInteractions();
+	}
+
+	private MockMultipartFile createMultipartFile() {
+		return new MockMultipartFile(
+			"image",
+			"originalFilename",
+			MediaType.IMAGE_PNG_VALUE,
+			"content".getBytes()
+		);
+	}
+
+	private Address createAddress() {
+		return new Address("서울특별시", "강남구", "청담동");
+	}
+
+	private User createUser(long id) throws Exception {
+		return ReflectionUtils.createUser(
+			id,
+			Set.of(RoleType.USER),
+			"test@mail.com",
+			"password",
+			"12345",
+			"https://user-default-profile-image-url",
+			LocalDate.of(2024, 1, 1),
+			Gender.ETC,
+			"01012345678",
+			null
+		);
+	}
+
+	private BassGuitar createBassGuitar(long id, User seller) throws Exception {
+		return ReflectionUtils.createBassGuitar(
+			id,
+			seller,
+			"Test electric guitar",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			BassGuitarBrand.FENDER,
+			BassGuitarPickUp.JAZZ,
+			BassGuitarPreAmplifier.ACTIVE,
+			GuitarColor.RED
+		);
+	}
+
+	private InstrumentImage createInstrumentImage(long id, Instrument instrument) throws Exception {
+		return ReflectionUtils.createInstrumentImage(
+			id,
+			instrument,
+			"original-image-name.png",
+			"stored-image-name",
+			"https://instrument-image"
+		);
+	}
+
+	private FileDto createFileDto() throws Exception {
+		return ReflectionUtils.createFileDto("original-name", "stored-name", "https://file-url");
+	}
+}

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentImageQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentImageQueryServiceTest.java
@@ -1,0 +1,116 @@
+package com.ajou.hertz.unit.domain.instrument.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ajou.hertz.common.entity.Address;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarBrand;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPickUp;
+import com.ajou.hertz.domain.instrument.constant.BassGuitarPreAmplifier;
+import com.ajou.hertz.domain.instrument.constant.GuitarColor;
+import com.ajou.hertz.domain.instrument.constant.InstrumentProgressStatus;
+import com.ajou.hertz.domain.instrument.entity.BassGuitar;
+import com.ajou.hertz.domain.instrument.entity.Instrument;
+import com.ajou.hertz.domain.instrument.entity.InstrumentImage;
+import com.ajou.hertz.domain.instrument.repository.InstrumentImageRepository;
+import com.ajou.hertz.domain.instrument.service.InstrumentImageQueryService;
+import com.ajou.hertz.domain.user.constant.Gender;
+import com.ajou.hertz.domain.user.constant.RoleType;
+import com.ajou.hertz.domain.user.entity.User;
+import com.ajou.hertz.util.ReflectionUtils;
+
+@DisplayName("[Unit] Service(Query) - Instrument Image")
+@ExtendWith(MockitoExtension.class)
+class InstrumentImageQueryServiceTest {
+
+	@InjectMocks
+	private InstrumentImageQueryService sut;
+
+	@Mock
+	private InstrumentImageRepository instrumentImageRepository;
+
+	@Test
+	void 악기_id가_주어지고_해당_악기의_이미지를_전부_조회한다() throws Exception {
+		// given
+		long instrumentId = 2L;
+		BassGuitar bassGuitar = createBassGuitar(instrumentId, createUser(1L));
+		List<InstrumentImage> expectedResult = List.of(
+			createInstrumentImage(3L, bassGuitar),
+			createInstrumentImage(4L, bassGuitar),
+			createInstrumentImage(5L, bassGuitar),
+			createInstrumentImage(6L, bassGuitar)
+		);
+		given(instrumentImageRepository.findAllByInstrument_Id(instrumentId)).willReturn(expectedResult);
+
+		// when
+		List<InstrumentImage> actualResult = sut.findAllByInstrumentId(instrumentId);
+
+		// then
+		then(instrumentImageRepository).should().findAllByInstrument_Id(instrumentId);
+		verifyEveryMocksShouldHaveNoMoreInteractions();
+		assertThat(actualResult.size()).isEqualTo(expectedResult.size());
+	}
+
+	private void verifyEveryMocksShouldHaveNoMoreInteractions() {
+		then(instrumentImageRepository).shouldHaveNoMoreInteractions();
+	}
+
+	private Address createAddress() {
+		return new Address("서울특별시", "강남구", "청담동");
+	}
+
+	private User createUser(long id) throws Exception {
+		return ReflectionUtils.createUser(
+			id,
+			Set.of(RoleType.USER),
+			"test@mail.com",
+			"password",
+			"12345",
+			"https://user-default-profile-image-url",
+			LocalDate.of(2024, 1, 1),
+			Gender.ETC,
+			"01012345678",
+			null
+		);
+	}
+
+	private BassGuitar createBassGuitar(long id, User seller) throws Exception {
+		return ReflectionUtils.createBassGuitar(
+			id,
+			seller,
+			"Test electric guitar",
+			InstrumentProgressStatus.SELLING,
+			createAddress(),
+			(short)3,
+			550000,
+			true,
+			"description",
+			BassGuitarBrand.FENDER,
+			BassGuitarPickUp.JAZZ,
+			BassGuitarPreAmplifier.ACTIVE,
+			GuitarColor.RED
+		);
+	}
+
+	private InstrumentImage createInstrumentImage(long id, Instrument instrument) throws Exception {
+		return ReflectionUtils.createInstrumentImage(
+			id,
+			instrument,
+			"original-image-name.png",
+			"stored-image-name",
+			"https://instrument-image"
+		);
+	}
+
+}

--- a/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
+++ b/src/test/java/com/ajou/hertz/unit/domain/instrument/service/InstrumentQueryServiceTest.java
@@ -351,24 +351,6 @@ class InstrumentQueryServiceTest {
 		);
 	}
 
-	private Instrument createInstrument(long instrumentId, User seller) throws Exception {
-		return ReflectionUtils.createBassGuitar(
-			instrumentId,
-			seller,
-			"Test electric guitar",
-			InstrumentProgressStatus.SELLING,
-			createAddress(),
-			(short)3,
-			550000,
-			true,
-			"description",
-			BassGuitarBrand.FENDER,
-			BassGuitarPickUp.JAZZ,
-			BassGuitarPreAmplifier.ACTIVE,
-			GuitarColor.RED
-		);
-	}
-
 	private ElectricGuitar createElectricGuitar(long id, User seller) throws Exception {
 		return ReflectionUtils.createElectricGuitar(
 			id,


### PR DESCRIPTION
## 🔥 Related Issue
- Close #83

## 🏃‍ Task
- AWS S3 파일 복수 삭제 기능 구현
- 악기 매물 삭제 API 구현

## 📄 Reference
- None
